### PR TITLE
Fix Cookie Access Bug Preventing Users from Logging In

### DIFF
--- a/modules/authorize.js
+++ b/modules/authorize.js
@@ -103,7 +103,10 @@ exports.getAuthorizationTokensViaRefresh = async function(req, res)
 
         // Throw the new token back into a cookie for the user to use
         var accessTypeAndToken = refreshAuthorizationResponse.tokenType + ' ' + refreshAuthorizationResponse.accessToken;
-        cookie.setCookie(req, res, accessKey, accessTypeAndToken, refreshAuthorizationResponse.tokenExpirationInMsec);
+        var cookieSettings = {
+            maxAge: refreshAuthorizationResponse.tokenExpirationInMsec
+        };
+        cookie.setCookie(req, res, accessKey, accessTypeAndToken, cookieSettings);
 
         // If the request did return a new refresh token, make sure we overwrite the old token
         if (refreshAuthorizationResponse.refreshToken !== undefined && refreshAuthorizationResponse.refreshToken !== null)
@@ -209,7 +212,10 @@ exports.setAuthorizationCookies = function(req, res, auth)
         }
 
         var accessTypeAndToken = auth.tokenType + ' ' + auth.accessToken;
-        cookie.setCookie(req, res, accessKey, accessTypeAndToken, auth.tokenExpirationInMsec);
+        var cookieSettings = {
+            maxAge: auth.tokenExpirationInMsec
+        };
+        cookie.setCookie(req, res, accessKey, accessTypeAndToken, cookieSettings);
         cookie.setCookie(req, res, refreshKey, auth.refreshToken); // Session cookie (no explicit expiration);
 
         // No return value, just indicate success

--- a/modules/cookie.js
+++ b/modules/cookie.js
@@ -42,7 +42,7 @@ exports.getCookie = function(req, cookieName)
     }
 }
 
-exports.setCookie = function(req, res, cookieName, cookieValue, cookieMaxAge)
+exports.setCookie = function(req, res, cookieName, cookieValue, cookieSettings)
 {
     try
     {
@@ -79,25 +79,26 @@ exports.setCookie = function(req, res, cookieName, cookieValue, cookieMaxAge)
         // Helps to prevent against cross-site scripting (XSS) attacks
         var useHttpOnlyFlag = true;
 
-        // Declare that the cookies should only be used by this app in a first party only context
-        var sameSiteSetting = 'Strict';
+        // Declare that the cookies will be sent when users or sites are navigating to this application's web pages (from anywhere)
+        // This needs to be 'Lax' instead of 'Strict' to allow cookies to be stored and accessed when logging into Spotify
+        var sameSiteSetting = 'Lax';
 
         // Sign cookies with a secret and read them back with the same secret to validate them
         var useSignedCookies = true;
 
-        var cookieOptions = {
+        // Default cookie options, to be used as default if no settings are specified
+        var defaultCookieOptions = {
             secure: useSecureCookiesOverHttps,
             httpOnly: useHttpOnlyFlag,
             sameSite: sameSiteSetting,
             signed: useSignedCookies
         };
 
-        // Session cookies do not have an explicit expiration
-        // Only set an expiration if one exists (and thus this is not a session cookie)
-        if (cookieMaxAge !== undefined && cookieMaxAge !== null)
-        {
-            cookieOptions['maxAge'] = cookieMaxAge;
-        }
+        // Overwrite any default cookie option with ones manually specified
+        var cookieOptions = {
+            ...defaultCookieOptions,
+            ...cookieSettings
+        };
 
         res.cookie(cookieName, cookieValue, cookieOptions);
 

--- a/modules/login.js
+++ b/modules/login.js
@@ -87,6 +87,7 @@ exports.validateLogin = async function(req, res)
     }
     catch (error)
     {
+        // TODO - Should do clean up here (in case login failed) to make sure that no cookies are stored and the user is not actually half logged in or in some weird state
         logger.logError('Failed to authorize user with Spotify: ' + error.message);
         res.redirect('/accessDenied');
         return;


### PR DESCRIPTION
### Overview

As reported in issue #24, some users cannot login properly.

After reviewing the logs, a good portion of the problem is around the login flow, which uses OAuth to call out to Spotify.

When the application calls out to Spotify and a user logs in, several cookies are required.  When calling out to Spotify and routing to the validate login callback function within the JAMMS app, the app could not access the cookies it needed to in order to log the user in, so login failed and a failure page showed up (as described in the issue).

The reason the application could not access the cookies was because of a cookie flag recently introduced called "SameSite".  More information here - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

With this value set to "Strict" by default within the application, only first party calls made from the app and to the app would be able to get cookies properly.  Without being able to get cookies, the login flow failed.

By setting this value to "Lax", we can allow calls made to the app (like from Spotify) to also pass along the cookies needed.  This will allow the checkout flow to proceed as intended.

### Testing

Grabbing the logs allowed for easier testing related to cookies.

Changed one setting at a time locally (except for secure since I was testing with HTTP) to observe the behavior locally, particularly in incognito and in Firefox where I did not already have login cookies saved in session on a browser.

Changing the default setting to "Lax" allowed proper login in Firefox.

