### PR TITLE
Handle Messy Login States

### DIFF
--- a/modules/authorize.js
+++ b/modules/authorize.js
@@ -228,7 +228,7 @@ exports.setAuthorizationCookies = function(req, res, auth)
     }
 }
 
-exports.deleteAuthorizationCookies = async function(req, res)
+exports.deleteAuthorizationCookies = async function(res)
 {
     try
     {

--- a/modules/error.js
+++ b/modules/error.js
@@ -1,29 +1,55 @@
+// Dependencies
+var path = require('path'); // URI and local file paths
+
+// Custom Modules
+const customModulePath = __dirname;
+var login = require(path.join(customModulePath, 'login.js'));
+
 // Error Handling Logic
-exports.handlePageNotFound = function(req, res)
+exports.handlePageNotFound = async function(req, res)
 {
+    var errorPageData = await getErrorPageData(req, res);
+
     res.location('notFound');
     res.status(404);
-    res.render('notFound');
+    res.render('notFound', errorPageData);
 }
 
-exports.handleAccessNotAllowed = function(req, res)
+exports.handleAccessNotAllowed = async function(req, res)
 {
+    var errorPageData = await getErrorPageData(req, res);
+
     res.location('accessDenied');
     res.status(403);
-    res.render('accessDenied');
+    res.render('accessDenied', errorPageData);
 }
 
-exports.handleExpectedError = function(req, res)
+exports.handleExpectedError = async function(req, res)
 {
+    var errorPageData = await getErrorPageData(req, res);
+
     res.location('error');
     res.status(500);
-    res.render('error');
+    res.render('error', errorPageData);
 }
 
-exports.handleUnexpectedError = function(err, req, res, next)
+exports.handleUnexpectedError = async function(err, req, res, next)
 {
+    var errorPageData = await getErrorPageData(req, res);
+
     res.location('error')
     res.status(500);
-    res.render('error');
+    res.render('error', errorPageData);
     next(err);
+}
+
+// Helper Functions
+async function getErrorPageData(req, res)
+{
+    var isUserLoggedIn = await login.isUserLoggedIn(req, res);
+    var errorPageData = {
+        isLoginError: !isUserLoggedIn
+    }
+
+    return errorPageData;
 }

--- a/modules/landing.js
+++ b/modules/landing.js
@@ -13,7 +13,12 @@ exports.getLandingPage = async function(req, res, next)
     try
     {
         // Try to get the home page if the user is already logged in or can authenticate
-        await login.isUserLoggedIn(req, res); // Rejects promise if user is not logged in
+        var isUserLoggedIn = await login.isUserLoggedIn(req, res);
+        if (!isUserLoggedIn)
+        {
+            throw new Error('User is not logged in. Falling back to landing page.');
+        }
+
         var homePageData = await home.getHomePageData(req, res);
         home.renderHomePage(res, homePageData);
     }

--- a/modules/login.js
+++ b/modules/login.js
@@ -80,14 +80,18 @@ exports.validateLogin = async function(req, res)
         var authorizationResponse = await authorize.getAuthorizationTokens(req, res);
 
         // Use the access token and refresh token to validate access to Spotify's API
-        var cookieResponse = authorize.setAuthorizationCookies(req, res, authorizationResponse);
+        var cookieResponse = await authorize.setAuthorizationCookies(req, res, authorizationResponse);
 
         // Once we have our tokens, redirect to the home page
         res.redirect('/home');
     }
     catch (error)
     {
-        // TODO - Should do clean up here (in case login failed) to make sure that no cookies are stored and the user is not actually half logged in or in some weird state
+        // Clean up any potentially set login cookies if login has failed
+        // This is to be sure that a user is not stuck in a half logged in state
+        await cookie.clearCookie(res, stateKey);
+        await authorize.deleteAuthorizationCookies(res);
+
         logger.logError('Failed to authorize user with Spotify: ' + error.message);
         res.redirect('/accessDenied');
         return;

--- a/modules/login.js
+++ b/modules/login.js
@@ -106,12 +106,12 @@ exports.isUserLoggedIn = async function(req, res)
         var accessToken = await authorize.getAccessToken(req, res);
 
         // If we have a valid refresh and access token, then a user can be considered logged in
-        return Promise.resolve();
+        return Promise.resolve(true);
     }
-    catch (error)
+    catch
     {
-        // User is not logged in
-        return Promise.reject(error);
+        // User is not logged in if we failed to get their login tokens (can swallow errors here)
+        return Promise.resolve(false);
     }
 }
 

--- a/modules/logout.js
+++ b/modules/logout.js
@@ -12,7 +12,7 @@ exports.logOut = async function(req, res, next)
     try
     {
         // Logging out just consists of removing cookies and redirecting to the landing page
-        await authorize.deleteAuthorizationCookies(req, res);
+        await authorize.deleteAuthorizationCookies(res);
 
         // Now that we have successfully logged out, redirect to the landing page
         res.redirect('/');

--- a/views/accessDenied.vash
+++ b/views/accessDenied.vash
@@ -4,5 +4,6 @@
     <p>
       We apologize, but we cannot let you access what you are requesting.
     </p>
+    <a id="landingButton" href="/" role="button" class="btn btn-info btn-sm">Return Home</a>
   })
 })

--- a/views/error.vash
+++ b/views/error.vash
@@ -1,11 +1,12 @@
 @html.extend('layout', function(model) {
 	@html.block('content', function(model) {
-    <h2 class="my-3">Request Error</h2>
+    <h2>Request Error</h2>
     <p>
       We apologize, but there was an error in trying to process your request.
     </p>
     <p>
       If the error persists, please <a href="@html.raw('mailto:admin@jamms.app')">contact us via e-mail</a> or <a href="https://github.com/iansantagata/jamms/issues">open an issue in our open-source repository</a> to help get the problem resolved.
     </p>
+    <a id="landingButton" href="/" role="button" class="btn btn-info btn-sm">Return Home</a>
   })
 })

--- a/views/layout.vash
+++ b/views/layout.vash
@@ -35,22 +35,21 @@
   <!-- TODO - Have to put a warning / acceptance alert about cookies eventually if they continue to be used -->
   <header class="card-header text-center mb-2">
     <div class="row">
-      @if(model.isAwaitingLogin)
+      @if(!model.isAwaitingLogin && !model.isLoginError)
       {
         <div class="col">
-          <h5 class="my-0">JAMMS</h5>
+          <a id="homeButton" href="/home" role="button" class="btn btn-info btn-sm">Home</a>
         </div>
       }
-      else
+
+      <div class="col">
+        <h5 class="my-0">JAMMS</h5>
+      </div>
+
+      @if(!model.isAwaitingLogin && !model.isLoginError)
       {
         <div class="col">
-          <a id="homeButton" href="/home" role="button" class="btn btn-info btn-sm stretched-link">Home</a>
-        </div>
-        <div class="col">
-          <h5 class="my-0">JAMMS</h5>
-        </div>
-        <div class="col">
-            <a id="logOutButton" href="/logout" role="button" class="btn btn-info btn-sm stretched-link">Log Out</a>
+            <a id="logOutButton" href="/logout" role="button" class="btn btn-info btn-sm">Log Out</a>
         </div>
       }
     </div>

--- a/views/notFound.vash
+++ b/views/notFound.vash
@@ -4,5 +4,6 @@
     <p>
       We apologize, but we cannot seem to find what you are looking for.
     </p>
+    <a id="landingButton" href="/" role="button" class="btn btn-info btn-sm">Return Home</a>
   })
 })


### PR DESCRIPTION
### Overview

As mentioned in issue #28, if the user runs into failures trying to login, they may enter a half-baked login state, depending on a variety of factors (primarily, which cookies were set successfully and which ones were not).

This change fixes the issue.  It ensures that all login flow cookies are deleted if login failed to ensure that login is all or nothing.  

It also makes error pages more clear and hides confusing buttons for the users in case they are not logged in.  (For example, it hides the "Log Out" button that was defaulted on error pages if a user is not logged since that does not really make sense.)

This also adds another minor change, making the error pages more clear by adding a button to return to the landing page.  This is done for simple routing and user experience.

Additionally, noteworthy that this is somewhat related to closed issue #24 as well.

### Testing

Tested with various login states by manually throwing an error at multiple different points.  Observed previous issue behavior where cookies are stored but home page fails to load because of manual error, causing confusion for users. 

Confirmed this change fixed the issue and removed confusing UI components that did not make sense given the user's login state on various pages (error pages included).