### PR TITLE
Remove Starting Rule in Smart Playlist Creation

### DIFF
--- a/public/scripts/createSmartPlaylist.js
+++ b/public/scripts/createSmartPlaylist.js
@@ -1,12 +1,11 @@
 "use strict";
 
 // Script Logic
-let lastActiveRuleIndex = 0;
+let ruleCounter = 0;
 
 addOnClickEventListenerToElementById("playlistLimitEnabledInput", controlEnablementOfLimitElements);
 addOnClickEventListenerToElementById("playlistOrderEnabledInput", controlEnablementOfOrderElements);
 
-addOnClickEventListenerToElementById(`removeRuleButton-${lastActiveRuleIndex}`, removeRuleFormFields);
 addOnClickEventListenerToElementById("addRuleButton", addRuleFormFields);
 
 addOnClickEventListenerToElementById("generateSmartPlaylistPreviewButton", previewSmartPlaylist);
@@ -326,7 +325,7 @@ function displayPreviewOutOfDateAlert()
 
 function addRuleFormFields()
 {
-    const ruleIndex = lastActiveRuleIndex + 1;
+    ruleCounter++;
 
     // Create pieces of the form row needed for the new rule
     // Rule Type Selection
@@ -353,7 +352,7 @@ function addRuleFormFields()
     songOptionRuleType.innerText = "Song Name";
 
     const selectRuleType = document.createElement("select");
-    selectRuleType.setAttribute("name", `playlistRuleType-${ruleIndex}`);
+    selectRuleType.setAttribute("name", `playlistRuleType-${ruleCounter}`);
     selectRuleType.setAttribute("class", "form-control");
     selectRuleType.setAttribute("required", "");
     selectRuleType.appendChild(albumOptionRuleType);
@@ -398,7 +397,7 @@ function addRuleFormFields()
     containsOptionRuleOperator.innerText = "contains";
 
     const selectRuleOperator = document.createElement("select");
-    selectRuleOperator.setAttribute("name", `playlistRuleOperator-${ruleIndex}`);
+    selectRuleOperator.setAttribute("name", `playlistRuleOperator-${ruleCounter}`);
     selectRuleOperator.setAttribute("class", "form-control");
     selectRuleOperator.setAttribute("required", "");
     selectRuleOperator.appendChild(equalOptionRuleOperator);
@@ -416,7 +415,7 @@ function addRuleFormFields()
     // Rule Text Data
     const inputRuleTextData = document.createElement("input");
     inputRuleTextData.setAttribute("type", "text");
-    inputRuleTextData.setAttribute("name", `playlistRuleData-${ruleIndex}`);
+    inputRuleTextData.setAttribute("name", `playlistRuleData-${ruleCounter}`);
     inputRuleTextData.setAttribute("class", "form-control");
     inputRuleTextData.setAttribute("placeholder", "Your Rule Data");
     inputRuleTextData.setAttribute("required", "");
@@ -429,7 +428,7 @@ function addRuleFormFields()
     const removeRuleButton = document.createElement("button");
     removeRuleButton.setAttribute("type", "button");
     removeRuleButton.setAttribute("name", "removeRuleButton");
-    removeRuleButton.setAttribute("id", `removeRuleButton-${ruleIndex}`);
+    removeRuleButton.setAttribute("id", `removeRuleButton-${ruleCounter}`);
     removeRuleButton.setAttribute("class", "btn btn-outline-danger btn-sm form-control");
     removeRuleButton.innerText = "Remove Rule";
 
@@ -440,7 +439,7 @@ function addRuleFormFields()
     // Add all the components to the top level rule div
     const ruleDiv = document.createElement("div");
     ruleDiv.setAttribute("class", "form-row my-2");
-    ruleDiv.setAttribute("id", `rule-${ruleIndex}`);
+    ruleDiv.setAttribute("id", `rule-${ruleCounter}`);
     ruleDiv.appendChild(ruleTypeDiv);
     ruleDiv.appendChild(ruleOperatorDiv);
     ruleDiv.appendChild(ruleTextDataDiv);
@@ -450,11 +449,8 @@ function addRuleFormFields()
     const rulesContainerElement = document.getElementById("rulesContainer");
     rulesContainerElement.appendChild(ruleDiv);
 
-    // Add an event listener to the remove rule button that has been added
+    // Finally, add an event listener to the remove rule button that has been added
     addOnClickEventListenerToElement(removeRuleButton, removeRuleFormFields);
-
-    // Finally, update the index of the last rule in case more are created
-    lastActiveRuleIndex = ruleIndex;
 }
 
 function removeRuleFormFields()

--- a/views/createSmartPlaylist.vash
+++ b/views/createSmartPlaylist.vash
@@ -14,37 +14,7 @@
           </div>
 
           <h4 class="my-3">Rules</h4>
-          <div id="rulesContainer">
-            <div class="form-row my-2" id="rule-0">
-              <div class="col-3">
-                <select name="playlistRuleType-0" class="form-control" required >
-                  <option value="album">Album Name</option>
-                  <option value="artist" selected>Artist Name</option>
-                  <!-- TODO - Add genre back in when it is ready to be used (developed) -->
-                  <!-- <option value="genre">Genre</option> -->
-                  <option value="year">Release Year</option>
-                  <option value="song">Song Name</option>
-                </select>
-              </div>
-              <div class="col-4">
-                <select name="playlistRuleOperator-0" class="form-control" required>
-                  <option value="equal" selected>is</option>
-                  <option value="notEqual">is not</option>
-                  <option value="greaterThan">is greater than</option>
-                  <option value="greaterThanOrEqual">is greater than or equal to</option>
-                  <option value="lessThan">is less than</option>
-                  <option value="lessThanOrEqual">is less than or equal to</option>
-                  <option value="contains">contains</option>
-                </select>
-              </div>
-              <div class="col-3">
-                <input type="text" name="playlistRuleData-0" class="form-control" placeholder="Your Rule Data" required />
-              </div>
-              <div class="col-2">
-                <button type="button" name="removeRuleButton" id="removeRuleButton-0" class="btn btn-outline-danger btn-sm form-control">Remove Rule</button>
-              </div>
-            </div>
-          </div>
+          <div id="rulesContainer"></div>
           <button type="button" name="addRuleButton" id="addRuleButton" class="btn btn-outline-info btn-sm my-3">Add Rule</button>
 
           <h4 class="my-3">Optional Settings</h4>


### PR DESCRIPTION
### Overview

This change addresses issue #29.  It removes the default empty starting rule when trying to create a smart playlist.

Users may have found starting with one rule that is "empty" and awaiting user data confusing and unclear when trying to create a smart playlist.  Instead, the "empty" starting rule has been removed, and if users wish to add rules to their smart playlist logic, they can do so by clicking the button themselves to add a rule.

This behavior is more transparent and less confusing (and error prone) for users simply trying to try out JAMMS' functionality.