### PR TITLE
Enable Smart Playlist to Utilize Genre

### DIFF
--- a/public/scripts/createSmartPlaylist.js
+++ b/public/scripts/createSmartPlaylist.js
@@ -141,7 +141,7 @@ function displaySmartPlaylistPreview(data)
     headerElement.setAttribute("class", "my-3");
     headerElement.innerText = "Smart Playlist Track Preview";
 
-    const textElement = document.createTextNode("Note - All playlist previews are generated on request and limited to the first 25 matching tracks.  Any created smart playlist may differ from the tracks shown in the preview.");
+    const textElement = document.createTextNode("Note - All playlist previews are generated on request. On top of the limits set above, previews are also limitied to the first 25 matching tracks found. Any created smart playlist may differ from the tracks shown in the preview.");
 
     const alertImageElement = document.createElement("i");
     alertImageElement.setAttribute("class", "bi-info-circle-fill mx-2");
@@ -338,10 +338,9 @@ function addRuleFormFields()
     artistOptionRuleType.setAttribute("selected", "");
     artistOptionRuleType.innerText = "Artist Name";
 
-    // TODO - Add Genre back in when it is fully developed
-    // TODO - var genreOptionRuleType = document.createElement("option");
-    // TODO - genreOptionRuleType.setAttribute("value", "genre");
-    // TODO - genreOptionRuleType.innerText = "Genre";
+    const genreOptionRuleType = document.createElement("option");
+    genreOptionRuleType.setAttribute("value", "genre");
+    genreOptionRuleType.innerText = "Genre";
 
     const yearOptionRuleType = document.createElement("option");
     yearOptionRuleType.setAttribute("value", "year");
@@ -357,8 +356,7 @@ function addRuleFormFields()
     selectRuleType.setAttribute("required", "");
     selectRuleType.appendChild(albumOptionRuleType);
     selectRuleType.appendChild(artistOptionRuleType);
-    // TODO - Add Genre back in when it is fully developed
-    // TODO - selectRuleType.appendChild(genreOptionRuleType);
+    selectRuleType.appendChild(genreOptionRuleType);
     selectRuleType.appendChild(yearOptionRuleType);
     selectRuleType.appendChild(songOptionRuleType);
 


### PR DESCRIPTION
### Overview

This change address issue #15.

One feature that was missing from smart playlist creation was allowing users to preview and create smart playlists based on different genres.  

This change restores the previously removed "genre" feature within smart playlists.  It allows users to utilize genre from artists on their smart playlist rules.

### Details

A genre rule was not included as initially functional when the site went live because it proved to be more complex than initially considered.  (Or rather, it was included, but was quickly disabled and temporarily removed since it was non-functional.)

Most data points included at launch were pieces of data that were immediately available from the tracks themselves, but within Spotify, genre is only stored on artist objects.  What's more, the nested artist object returned as part of a track is a simplified object that does not include genre information with it.

An enrichment layer was needed to call out to Spotify for missing information and enrich tracks with that data.  This would allow users to create smart playlists as they had before, but now with the genre data they want included now "associated" with the track through this enrichment.

### Testing

Tested using several genres, particularly "Tropical House" and "Classic Rock", which are two fully named genres within Spotify.

This change brought to light several issues throughout testing, particularly the following that will not be handled as part of this change (but will be handled in future changes):

- #45 
- #44 