### PR TITLE
Fix Over Hundred Songs Smart Playlist Bug

### DIFF
--- a/modules/spotifyClient.js
+++ b/modules/spotifyClient.js
@@ -35,6 +35,7 @@ const artistRequestLimitDefault = 10;
 const artistRequestLimitMax = 50;
 const artistIdsLimitMax = 50;
 const artistPageNumberDefault = 1;
+const trackAddToPlaylistLimitMax = 100;
 const tracksRequestLimitDefault = 10;
 const tracksRequestLimitMax = 50;
 const tracksPageNumberDefault = 1;
@@ -374,9 +375,14 @@ exports.addTracksToPlaylist = async function(req, res)
         }
 
         const trackUris = req.body.trackUris;
-        if (!trackUris || typeof trackUris !== "object")
+        if (!trackUris || !Array.isArray(trackUris))
         {
             throw new Error(`Invalid track URIs of "${trackUris}" to add to playlist`);
+        }
+
+        if (trackUris.length <= 0 || trackUris.length > trackAddToPlaylistLimitMax)
+        {
+            throw new Error(`Invalid number of track URIs of "${trackUris.length}"`);
         }
 
         const requestData = {


### PR DESCRIPTION
### Overview

This change fixes a bug where smart playlists were created, but songs were not added to them.  The bug was caused by an issue within the app itself where songs were not batched into groups of 100.

Spotify's API for adding songs to a playlist is capped at 100 songs at a time.  If more than 100 songs are sent, it throws a 400 error back to the caller.  This prevented any smart playlist of 101 songs or more from being generated.

By leveraging previous helper functionality (specifically around chunking), this issue no longer exists.

### Testing

Utilized similar tests as done in the genre PR #46 (where this issue was first uncovered).

Specifically, created "Classic Rock" and "Tropical House" playlists with my library and observed that playlists were created with over 100 songs in them without error after this change.  

Also confirmed that before this change, an error would arise and empty playlists would be created with those same examples.