### PR TITLE
Make Contains and Equals Logic More Robust

### DIFF
--- a/modules/smartPlaylist.js
+++ b/modules/smartPlaylist.js
@@ -510,10 +510,9 @@ function getArtistsFromSavedTrack(savedTrack)
 function getArtistNamesFromSavedTrack(savedTrack)
 {
     // A track can have multiple artists and is usually in a particular order
-    // Take all the artists on a track and join them into a single comma separated string
+    // Take all the artists on a track in array form to get all of the artists
     return getArtistsFromSavedTrack(savedTrack)
-        .map(getArtistNameFromArtist)
-        .join(", ");
+        .map(getArtistNameFromArtist);
 }
 
 function getReleaseDateFromSavedTrack(savedTrack)
@@ -1031,8 +1030,8 @@ function compareByReleaseDescending(targetTrack, existingTrack)
 
 function compareByArtistAscending(targetTrack, existingTrack)
 {
-    const targetTrackArtists = getArtistNamesFromSavedTrack(targetTrack);
-    const existingTrackArtists = getArtistNamesFromSavedTrack(existingTrack);
+    const targetTrackArtists = getArtistNamesFromSavedTrack(targetTrack).join(", ");
+    const existingTrackArtists = getArtistNamesFromSavedTrack(existingTrack).join(", ");
 
     if (targetTrackArtists < existingTrackArtists)
     {
@@ -1049,8 +1048,8 @@ function compareByArtistAscending(targetTrack, existingTrack)
 
 function compareByArtistDescending(targetTrack, existingTrack)
 {
-    const targetTrackArtists = getArtistNamesFromSavedTrack(targetTrack);
-    const existingTrackArtists = getArtistNamesFromSavedTrack(existingTrack);
+    const targetTrackArtists = getArtistNamesFromSavedTrack(targetTrack).join(", ");
+    const existingTrackArtists = getArtistNamesFromSavedTrack(existingTrack).join(", ");
 
     if (targetTrackArtists < existingTrackArtists)
     {

--- a/modules/smartPlaylist.js
+++ b/modules/smartPlaylist.js
@@ -1030,8 +1030,11 @@ function compareByReleaseDescending(targetTrack, existingTrack)
 
 function compareByArtistAscending(targetTrack, existingTrack)
 {
-    const targetTrackArtists = getArtistNamesFromSavedTrack(targetTrack).join(", ");
-    const existingTrackArtists = getArtistNamesFromSavedTrack(existingTrack).join(", ");
+    const targetTrackArtists = getArtistNamesFromSavedTrack(targetTrack)
+        .join(", ");
+
+    const existingTrackArtists = getArtistNamesFromSavedTrack(existingTrack)
+        .join(", ");
 
     if (targetTrackArtists < existingTrackArtists)
     {
@@ -1048,8 +1051,11 @@ function compareByArtistAscending(targetTrack, existingTrack)
 
 function compareByArtistDescending(targetTrack, existingTrack)
 {
-    const targetTrackArtists = getArtistNamesFromSavedTrack(targetTrack).join(", ");
-    const existingTrackArtists = getArtistNamesFromSavedTrack(existingTrack).join(", ");
+    const targetTrackArtists = getArtistNamesFromSavedTrack(targetTrack)
+        .join(", ");
+
+    const existingTrackArtists = getArtistNamesFromSavedTrack(existingTrack)
+        .join(", ");
 
     if (targetTrackArtists < existingTrackArtists)
     {

--- a/modules/smartPlaylist.js
+++ b/modules/smartPlaylist.js
@@ -590,16 +590,53 @@ function lessThanOrEqualTo(a, b)
     return lessThan(a, b) || equals(a, b);
 }
 
-// TODO - Change this so it's a few different things based on the case:
-// TODO - 1. If A is an array, contains B as an element within A
-// TODO - 2. If A is a string, contains a substring B within A
-// TODO - 3. If A is an object, contains a value B within A
-// TODO - 4. If A is a map, contains a key B within A
-// TODO - 5. If A is undefined or null, return false (rather than throwing an error)
-// TODO - 6. If A is an array and its elements A` are strings, contains a substring B within element A`
-function contains(a, b)
+// Note - The verb "contains" implies a lot of different possibilities
+// This function means to address as many of them as possible
+function contains(a, b, recurseDepth = 0)
 {
-    return a.includes(b);
+    if (!a || recurseDepth > 3)
+    {
+        return false;
+    }
+
+    if (typeof a === "string")
+    {
+        return a.includes(b);
+    }
+
+    if (a instanceof Map || a instanceof Set)
+    {
+        return a.has(b);
+    }
+
+    if (Array.isArray(a))
+    {
+        // If input is an array and it simply has the data name exactly, then we have found our target
+        if (a.includes(b))
+        {
+            return true;
+        }
+
+        // When input does not have exact data name, try recursion for sub-strings and sub-arrays and sub-objects as applicable
+        // Break if a positive result is found to prevent further processing
+        for (const elementOfA of a)
+        {
+            if (contains(elementOfA, b, recurseDepth + 1))
+            {
+                return true;
+            }
+        }
+
+        // If no result came back positive for the array, then the target does not exist within the array
+        return false;
+    }
+
+    if (typeof a === "object")
+    {
+        return Object.values(a).includes(b);
+    }
+
+    return false;
 }
 
 // Rule Functions


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
As part of the logic with the smart playlist generation, the verbs "contains" and "equals" particularly were not very robust.

The previous logic could not handle cases such as:

- Song name contains "Sing" substring (would not search substrings, only complete strings for exact matches)
- One of the song's artists is "Foo Fighters" on songs with multiple artists (would not search for single artist match when multiple artists were present)
- Genre desired is "rock" which should include "alternative rock" and "grunge rock" (would only return exact matches to "rock")

These cases and more have been addressed by making the operators of "contains" and "equals" in particular more robust.  By extension, this also impacts any other operators using these as a reference, including "not equals", "greater than or equals", "does not contain" (future addition), etc.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested with multiple options for "contains" and "equals" including songs with multiple artists, multiple genres, and substrings of song titles.

Particular test cases included:

- "Foo Fighters" artist for "contains" and "equals"
- "Third Eye Blind" artist for "equals" and "not equals"
- "Zedd" for multiple artists featured on a song with "contains" and "equals"
- "Rock" for genres with "contains" and "equals"

#### Additional Notes
<!-- This section can optionally be included if there is anything else in particular to note about this PR, like surrounding context, the issues it uncovered or resolved, etc. -->
This will be easily extendable to "does not contain", a future operator to include as reported in issue #44.
