### PR TITLE
Remove TODOs in JAMMS Code

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -144,9 +144,8 @@ rules:
     - error
   no-void:
     - error
-  # Help to keep track of TODOs until they can be removed and this be changed to error
   no-warning-comments:
-    - warn
+    - error
   no-whitespace-before-property:
     - error
 

--- a/modules/login.js
+++ b/modules/login.js
@@ -127,5 +127,3 @@ function generateRandomString(targetLength)
     }
     return text;
 }
-
-// TODO - Figure out how to make it so that user can login with different Spotify account from login screen

--- a/modules/logout.js
+++ b/modules/logout.js
@@ -25,5 +25,3 @@ exports.logOut = async function(req, res, next)
         next(error);
     }
 };
-
-// TODO - Should this clear Spotify cookies too so users can login to a different account if they choose?

--- a/modules/smartPlaylist.js
+++ b/modules/smartPlaylist.js
@@ -159,7 +159,6 @@ async function getSmartPlaylistData(req, res)
         req.query.tracksPerPage = tracksPerPageDefault; // Maximum value of tracks to retrieve per page
 
         // Loop over all songs in the library in batches
-        // TODO - Make the song retrieval area configurable (library, playlist, etc)
         while (canRetrieveMoreBatches)
         {
             // Get all the tracks in this batch
@@ -193,7 +192,6 @@ async function getSmartPlaylistData(req, res)
                 let trackFollowsAllRules = true;
                 for (const playlistRule of playlistRules)
                 {
-                    // TODO - Figure out a way to make AND and OR rules work here
                     if (!playlistRule.function(trackInBatch, playlistRule.data, playlistRule.operator))
                     {
                         trackFollowsAllRules = false;

--- a/public/scripts/createSmartPlaylist.js
+++ b/public/scripts/createSmartPlaylist.js
@@ -108,8 +108,6 @@ function handlePlaylistPreviewError(error)
 
 function displaySmartPlaylistPreview(data)
 {
-    // TODO - Might be a good idea to throw the preview into a modal of its own instead of on the same page
-    // TODO - That does come with some pros and cons however (editing rules in place, regenerating previews, etc)
     if (!data)
     {
         const dataNotFoundError = new Error("Failed to find AJAX response data");

--- a/public/scripts/helperFunctions.js
+++ b/public/scripts/helperFunctions.js
@@ -203,8 +203,6 @@ function getCommaSeparatedArtistNames(artists)
 
 function getImagePath(images, minimumPixelsPerSide, defaultImagePath)
 {
-    // TODO - This function should be fixed and the <img> objects adjusted so that they display relatively the same size images for all <img> tags on a page or in a group
-
     // Make sure we actually have images, or else we can short circuit
     if (!Array.isArray(images) || images.length === 0)
     {

--- a/public/scripts/viewPlaylist.js
+++ b/public/scripts/viewPlaylist.js
@@ -1,6 +1,5 @@
 "use strict";
 
 // Script Logic
-addOnClickEventListenerToElementById("editPlaylistDetailsButton", controlLoadingIndicatorWithText);
 addOnClickEventListenerToElementById("restorePlaylistButton", controlLoadingIndicatorWithText);
 addOnClickEventListenerToElementById("deletePlaylistButton", controlLoadingIndicatorWithText);

--- a/public/scripts/viewPlaylists.js
+++ b/public/scripts/viewPlaylists.js
@@ -1,5 +1,10 @@
 "use strict";
 
+// Constants
+const playlistsPerPageIncrement = 10;
+const playlistsPerPageStart = 10;
+const playlistsPerPageMaximum = 50;
+
 // Script Logic
 addOnClickListenersForPlaylistPerPageLinks();
 addOnClickListenersForViewPlaylistLinks();
@@ -189,6 +194,33 @@ function addPageNavigationButtons(currentPageNumber, numberOfPlaylistsPerPage, m
 
     // Finally, make sure that all of the necessary elements have event handlers
     addOnClickListenersForPlaylistsPageNavigationLinks();
+}
+
+function addPlaylistsPerPageDropdownOptions(numberOfPlaylistsPerPageSelected)
+{
+    let playlistsPerPage = playlistsPerPageStart;
+    const containerElement = document.getElementById("playlistsPerPageDropdownOptionsContainer");
+
+    while (playlistsPerPage > 0 && playlistsPerPage <= playlistsPerPageMaximum)
+    {
+        const linkElement = document.createElement("a");
+        linkElement.innerText = playlistsPerPage;
+
+        if (playlistsPerPage === numberOfPlaylistsPerPageSelected)
+        {
+            linkElement.setAttribute("class", "dropdown-item disabled");
+            linkElement.setAttribute("href", "#");
+        }
+        else
+        {
+            linkElement.setAttribute("id", `playlistsPerPageLink-${playlistsPerPage}`);
+            linkElement.setAttribute("class", "dropdown-item");
+            linkElement.setAttribute("href", `/playlists?playlistsPerPage=${playlistsPerPage}`);
+        }
+
+        containerElement.appendChild(linkElement);
+        playlistsPerPage += playlistsPerPageIncrement;
+    }
 }
 
 function getPlaylistsPageNavigationUrl(targetPageNumber, numberOfPlaylistsPerPage)

--- a/views/landing.vash
+++ b/views/landing.vash
@@ -5,8 +5,6 @@
 
     <div id="login" class="mb-3">
         <h1 class="my-3">Welcome to JAMMS!</h1>
-        <!-- TODO - Put some kind of cool placeholder image here -->
-
         <a id="loginToSpotifyButton" href="/login" role="button" class="my-3 btn btn-primary">Log in with Spotify to Use JAMMS</a>
     </div>
 

--- a/views/layout.vash
+++ b/views/layout.vash
@@ -32,7 +32,6 @@
 
   <script defer src="scripts/layout.js"></script>
 
-  <!-- TODO - Have to put a warning / acceptance alert about cookies eventually if they continue to be used -->
   <header class="card-header text-center mb-2">
     <div class="row">
       @if(!model.isAwaitingLogin && !model.isLoginError)

--- a/views/viewPlaylist.vash
+++ b/views/viewPlaylist.vash
@@ -54,11 +54,6 @@
     </div>
 
     <div id="interact" class="row align-items-center justify-content-center mb-5">
-      <!-- TODO - Add endpoint for playlist detail editing, including playlist image -->
-      <div class="col">
-        <a id="editPlaylistDetailsButton" href="/editPlaylist?playlistId=@model.playlistId"
-            role="button" class="btn btn-info btn-sm disabled">Edit Playlist Details - Coming Soon!</a>
-      </div>
       @if(model.deleted)
       {
         <div class="col">

--- a/views/viewPlaylists.vash
+++ b/views/viewPlaylists.vash
@@ -10,52 +10,12 @@
       <div class="input-group justify-content-center">
         <div class="dropdown input-group-prepend">
           <button id="playlistsPerPageDropdown" class="btn btn-outline-info btn-sm dropdown-toggle" type="button" data-toggle="dropdown">Playlists Per Page</button>
-          <div class="dropdown-menu">
-            <!-- TODO - Refactor this in JS instead of Vash -->
-            @if(model.numberOfPlaylistsPerPage !== 10)
-            {
-              <a id="playlistsPerPageLink-10" class="dropdown-item" href="/playlists?playlistsPerPage=10">10</a>
-            }
-            else
-            {
-              <a class="dropdown-item disabled" href="#">10</a>
-            }
+          <div id="playlistsPerPageDropdownOptionsContainer" class="dropdown-menu">
+            <script type="text/javascript">
+              var playlistsPerPageSelected = @model.numberOfPlaylistsPerPage;
 
-            @if(model.numberOfPlaylistsPerPage !== 20)
-            {
-              <a id="playlistsPerPageLink-20" class="dropdown-item" href="/playlists?playlistsPerPage=20">20</a>
-            }
-            else
-            {
-              <a class="dropdown-item disabled" href="#">20</a>
-            }
-
-            @if(model.numberOfPlaylistsPerPage !== 30)
-            {
-              <a id="playlistsPerPageLink-30" class="dropdown-item" href="/playlists?playlistsPerPage=30">30</a>
-            }
-            else
-            {
-              <a class="dropdown-item disabled" href="#">30</a>
-            }
-
-            @if(model.numberOfPlaylistsPerPage !== 40)
-            {
-              <a id="playlistsPerPageLink-40" class="dropdown-item" href="/playlists?playlistsPerPage=40">40</a>
-            }
-            else
-            {
-              <a class="dropdown-item disabled" href="#">40</a>
-            }
-
-            @if(model.numberOfPlaylistsPerPage !== 50)
-            {
-              <a id="playlistsPerPageLink-50" class="dropdown-item" href="/playlists?playlistsPerPage=50">50</a>
-            }
-            else
-            {
-              <a class="dropdown-item disabled" href="#">50</a>
-            }
+              addPlaylistsPerPageDropdownOptions(playlistsPerPageSelected);
+            </script>
           </div>
         </div>
         <div class="input-group-append">


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
This change removes all TODOs in JAMMS code.  It does so in JS, HTML, and Vash files.

It also updates the JS lint settings to throw an error when a TODO is found in code.  Since this change removes all of them, it should pass linting now.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Confirmed that linting previously failed the code when TODOs existed but the lint rules were changed to error.

Tested refactor of playlists logic where code was moved from Vash to JavaScript to confirm that functionality remained the same (it did).