### PR TITLE
Paralellize Home Page Spotify Requests

### DIFF
--- a/modules/spotifyClient.js
+++ b/modules/spotifyClient.js
@@ -80,29 +80,36 @@ exports.getUserData = async function(req, res)
         // Get number of playlists and sample playlists from the user
         req.query.playlistsPerPage = defaultDataPointsPerPage;
         req.query.pageNumber = 1;
-        const playlistResponse = await exports.getAllPlaylists(req, res);
+        const playlistResponseAwaitable = exports.getAllPlaylists(req, res);
 
         // Get sample top artists from the user
         req.query.artistsPerPage = defaultDataPointsPerPage;
         req.query.pageNumber = 1;
         req.query.timeRange = spotifyLongTerm;
-        const topArtistsResponse = await exports.getTopArtists(req, res);
+        const topArtistsResponseAwaitable = exports.getTopArtists(req, res);
 
         // Get number of artists from the user
         req.query.artistsPerPage = 1;
         req.query.pageNumber = 1;
-        const artistsResponse = await exports.getAllArtists(req, res);
+        const artistsResponseAwaitable = exports.getAllArtists(req, res);
 
         // Get sample top tracks from the user
         req.query.tracksPerPage = defaultDataPointsPerPage;
         req.query.pageNumber = 1;
         req.query.timeRange = spotifyLongTerm;
-        const topTracksResponse = await exports.getTopTracks(req, res);
+        const topTracksResponseAwaitable = exports.getTopTracks(req, res);
 
         // Get number of tracks from the user
         req.query.tracksPerPage = 1;
         req.query.pageNumber = 1;
-        const tracksResponse = await exports.getAllTracks(req, res);
+        const tracksResponseAwaitable = exports.getAllTracks(req, res);
+
+        // Resolve all the promises so that we have actual data returned after firing each request off
+        const playlistResponse = await playlistResponseAwaitable;
+        const topArtistsResponse = await topArtistsResponseAwaitable;
+        const artistsResponse = await artistsResponseAwaitable;
+        const topTracksResponse = await topTracksResponseAwaitable;
+        const tracksResponse = await tracksResponseAwaitable;
 
         // Now aggregate all of the responses together to a single block of user data
         const fullSpotifyResponse = {


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
The home page calls out to many different Spotify endpoints to aggregate data.  However, it currently does so in series.

This performance hit is felt by the user waiting for the home page to load as each request is made to Spotify and then needs to resolve.

By parallelizing these requests, we only make the user wait for the length of the longest request until the home page loads rather than having to wait the sum of all of the request times.  This will drastically help performance on home page time loading, particularly for users that have a lot of data within Spotify.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested by calling the home page before making the change and after.  Observed significant home page load time improvements.

Test data below:

Parallel: 675 - 850 msec
Series: 2.0 - 2.3 seconds