### PR TITLE
Show Login Dialog on JAMMS Login

### DIFF
--- a/modules/login.js
+++ b/modules/login.js
@@ -36,6 +36,7 @@ exports.getLoginPage = async function(req, res, next)
             redirect_uri: redirectUri,
             response_type: "code",
             scope: scopes,
+            show_dialog: true,
             state: stateToken
         };
 


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
Currently, users already logged into the app who want to login as a different Spotify account cannot do so.  

Users can log in and out of JAMMS just fine, but Spotify stores cookies and session data to bypass the login if a user has already logged in on a browser.  This prevents the user from controlling which account they log into if they have already done so in the browser before.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested by logging in, logging out, and then logging in again to see the dialog option where user account can be switched via Spotify.

#### Additional Notes
<!-- This section can optionally be included if there is anything else in particular to note about this PR, like surrounding context, the issues it uncovered or resolved, etc. -->
Uncovered the parameter `show_dialog: true` in this StackOverflow here: https://stackoverflow.com/questions/24408444/how-to-logout-user-from-spotify-after-authorization-and-web-api-call-is-over
