### PR TITLE
Add CODEOWNERS File and PR Approval Functionality

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in the repository.
+# Unless a later match takes precedence, these owners will be requested for review when someone opens a pull request.
+
+*   @iansantagata


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
CODEOWNERS functionality will be required if users are looking to get approved reviews on PRs.

This should be done so that anyone can open a PR, but only select people can approve it to get it merged to `master`.

#### Additional Notes
<!-- This section can optionally be included if there is anything else in particular to note about this PR, like surrounding context, the issues it uncovered or resolved, etc. -->
Utilized this documentation to write this file - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Additionally, changed the repository settings to require CODEOWNERS reviews for PRs.
