### PR TITLE
Field and Operator Combination Sensibility

### DIFF
--- a/public/scripts/createSmartPlaylist.js
+++ b/public/scripts/createSmartPlaylist.js
@@ -21,6 +21,8 @@ function previewSmartPlaylist()
     const formElement = getClosestForm(eventElement);
     if (!formElement)
     {
+        const formElementNotFoundError = new Error("Failed to find closest related form element");
+        console.error(formElementNotFoundError);
         return;
     }
 
@@ -883,12 +885,16 @@ function removeRuleFormFields()
     const index = eventElementId.lastIndexOf("-");
     if (index === -1)
     {
+        const ruleNumberNotFoundError = new Error("Failed to find rule number from event ID");
+        console.error(ruleNumberNotFoundError.message);
         return;
     }
 
     const targetRuleNumber = eventElementId.substr(index + 1);
     if (targetRuleNumber === "")
     {
+        const ruleNotFoundError = new Error("Failed to find rule data");
+        console.error(ruleNotFoundError.message);
         return;
     }
 


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
When filling out a smart playlist rule, sometimes, the data field and the operator used are nonsensical or confusing to the user.

For example, "Release year contains X" is a confusing rule that is allowed to be entered.  

Does this mean that if the user enters a "19", it'll include every year that ended in "19" as well as every year in the "1900s"?  

The input field allows text as well even though release year is a numeric.  How does "Release year contains 'abc123'" behave?  This is confusing at worst and nonsensical at best from a user perspective.

This change restricts the combinations of data fields and operators / data entry input to only sensible ones.  

For example, when the data field expects a string (like "Song Name"), operators available are variations of "is" and "contains", and the data entry field allows text. 

As another example, when the data field expects a number (like "Release Year"), operators available are variations of "is", "greater than", and "less than", and the data entry field allows only numbers.

This should lead to drastically less confused users when creating rules and a better user experience overall.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested with multiple combinations, some included below with results of now restricted options (that no longer are allowed):

- Release Year with Contains - Restricted
- Artist Name with Greater Than - Restricted
- Release Year with Is - Allowed
- Genre with Less Than - Restricted
- Album Name with Is Not - Allowed
- Release Year with Less Than or Equal To - Allowed
- Song Name with Does Not Contain - Allowed

Loosely, this corresponds to what is expected:

- String with Mathematical Inequality Operators - Restricted
- String with Equivalence Operators - Allowed
- String with String Contains Operators - Allowed
- Number with Mathematical Inequality Operators - Allowed
- Number with Equivalence Operators - Allowed
- Number with String Contains Operators - Restricted

Also tested and confirmed the following cases:

- Choosing initial data field enables operator input and data entry input
- Choosing initial data field populates valid operator options and data entry input type based on data field type
- Choosing subsequent data field on the same rule has no disabling effect on other rule inputs
- Choosing subsequent data field on the same rule clears out operator input value and data entry input value
- Choosing subsequent data field on the same rule re-populates valid operator options and data entry input type based on data field type
- Changing any field input value still triggers preview changed warning message
