### PR TITLE
Fix Smart Playlist User Description Bug

### DIFF
--- a/modules/smartPlaylist.js
+++ b/modules/smartPlaylist.js
@@ -362,7 +362,7 @@ function getPlaylistDescription(playlistLimitData, playlistOrderData)
     if (playlistLimitData.enabled)
     {
         playlistDescription += playlistDescriptionLimitPrefix + playlistDescriptionSpace +
-            playlistLimitData.value + playlistDescriptionSpace +
+            playlistLimitData.userSpecifiedValue + playlistDescriptionSpace +
             playlistLimitData.userSpecifiedType + playlistDescriptionPeriod + playlistDescriptionSpace;
     }
 

--- a/modules/smartPlaylistModules/limits.js
+++ b/modules/smartPlaylistModules/limits.js
@@ -26,6 +26,7 @@ exports.getPlaylistLimits = function(req)
         enabled: false,
         type: null,
         userSpecifiedType: null,
+        userSpecifiedValue: null,
         value: null
     };
 
@@ -53,6 +54,7 @@ exports.getPlaylistLimits = function(req)
     }
 
     // Make sure that the user specified playlist limit is a valid one that the app knows how to handle
+    playlistLimitData.userSpecifiedValue = playlistLimitData.value;
     playlistLimitData.userSpecifiedType = req.body.playlistLimitType;
     switch (playlistLimitData.userSpecifiedType)
     {


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
A bug was uncovered in the playlist details creation for smart playlists.

When a user selects "minutes" or "hours", the app converts this under the hood to milliseconds to be easier to work with mathematically for Spotify's songs (which have track length times stored in msec).

When displaying a created smart playlist to the user, this msec value never gets converted back to "minutes" or "hours" that was selected by the user.  The description ends being incorrect based on what the user entered, which is a confusing user experience since it is not aligned with what they selected.

For example, if a user entered a limit of "3 hours", the created playlist description would show "10800000 hours".  10,800,000 msec is 10,800 seconds which is 180 minutes which is 3 hours.  Mathematically, this is the correct msec value, but it is being displayed to the user as their entered value rather than "3".  The type showing "hours" is correct and what the user selected, but the number is incorrect since it is in units of msec.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested by creating a playlist with a 3 hour limit.

Re-created issue locally and confirmed this change fixes the problem.

#### Additional Notes
<!-- This section can optionally be included if there is anything else in particular to note about this PR, like surrounding context, the issues it uncovered or resolved, etc. -->
Bug reported by user @merrazquin.
