### PR TITLE
Introduce Beats Per Minute Rule Option for Smart Playlists

### DIFF
--- a/modules/smartPlaylist.js
+++ b/modules/smartPlaylist.js
@@ -197,7 +197,8 @@ async function getRuleFollowingSmartPlaylistTracks(req, res, isPlaylistPreview, 
                     req,
                     res,
                     savedTracksInBatch,
-                    trackIdToAudioFeaturesMap);
+                    trackIdToAudioFeaturesMap
+                );
 
                 savedTracksInBatch = await enrichment.enrichTracksWithAudioFeatures(savedTracksInBatch, trackIdToAudioFeaturesMap);
             }

--- a/modules/smartPlaylist.js
+++ b/modules/smartPlaylist.js
@@ -164,6 +164,7 @@ async function getRuleFollowingSmartPlaylistTracks(req, res, isPlaylistPreview, 
         // Then the app can retrieve that data and enrich the track with the data manually
         const playlistSpecialRuleFlags = specialRules.getPlaylistSpecialRuleFlags(playlistRules);
         let artistIdToGenresMap = new Map();
+        let trackIdToAudioFeaturesMap = new Map();
 
         // Keep track of the tracks to be in the playlist and the order of them as well
         const savedTracksInPlaylist = [];
@@ -188,6 +189,17 @@ async function getRuleFollowingSmartPlaylistTracks(req, res, isPlaylistPreview, 
             {
                 artistIdToGenresMap = await specialRules.getArtistIdToGenreMap(req, res, savedTracksInBatch, artistIdToGenresMap);
                 savedTracksInBatch = await enrichment.enrichTracksWithGenres(savedTracksInBatch, artistIdToGenresMap);
+            }
+
+            if (playlistSpecialRuleFlags.has("audioFeatures"))
+            {
+                trackIdToAudioFeaturesMap = await specialRules.getTrackIdToAudioFeaturesMap(
+                    req,
+                    res,
+                    savedTracksInBatch,
+                    trackIdToAudioFeaturesMap);
+
+                savedTracksInBatch = await enrichment.enrichTracksWithAudioFeatures(savedTracksInBatch, trackIdToAudioFeaturesMap);
             }
 
             // Process each track in the batch

--- a/modules/smartPlaylistModules/dataRetrieval.js
+++ b/modules/smartPlaylistModules/dataRetrieval.js
@@ -63,6 +63,11 @@ exports.getGenresFromSavedTrack = function(savedTrack)
     return savedTrack.track.genres;
 };
 
+exports.getBeatsPerMinuteFromSavedTrack = function(savedTrack)
+{
+    return savedTrack.track.audio_features.tempo;
+}
+
 exports.getArtistNameFromArtist = function(artist)
 {
     return artist.name.toUpperCase();

--- a/modules/smartPlaylistModules/dataRetrieval.js
+++ b/modules/smartPlaylistModules/dataRetrieval.js
@@ -66,7 +66,7 @@ exports.getGenresFromSavedTrack = function(savedTrack)
 exports.getBeatsPerMinuteFromSavedTrack = function(savedTrack)
 {
     return savedTrack.track.audio_features.tempo;
-}
+};
 
 exports.getArtistNameFromArtist = function(artist)
 {

--- a/modules/smartPlaylistModules/enrichment.js
+++ b/modules/smartPlaylistModules/enrichment.js
@@ -57,3 +57,34 @@ exports.enrichTracksWithGenres = function(savedTracks, artistIdToGenresMap)
         return Promise.reject(error);
     }
 };
+
+exports.enrichTracksWithAudioFeatures = function(savedTracks, trackIdToAudioFeaturesMap)
+{
+    try
+    {
+        for (const savedTrack of savedTracks)
+        {
+            // Check the mapping for a track ID to its corresponding audio features
+            // If we do not have audio features for this track, simply use an empty object
+            let audioFeatures = {};
+            const trackId = savedTrack.track.id;
+            if (trackIdToAudioFeaturesMap.has(trackId))
+            {
+                audioFeatures = trackIdToAudioFeaturesMap.get(trackId);
+            }
+
+            // Finally, set the audio features onto the track object
+            savedTrack.track.audio_features = audioFeatures;
+        }
+
+        // When finished adding audio features to the tracks, return the modified tracks
+        return Promise.resolve(savedTracks);
+    }
+    catch (error)
+    {
+        // If there is a problem with the enrichment, then a user's request related to audio features data cannot realistically succeed
+        // Best to log the error and reject to avoid a situation where users are built an undesireable smart playlist
+        logger.logError(`Failed to enrich tracks with audio features: ${error.message}`);
+        return Promise.reject(error);
+    }
+};

--- a/modules/smartPlaylistModules/rules.js
+++ b/modules/smartPlaylistModules/rules.js
@@ -108,6 +108,7 @@ function getRuleFunction(ruleType)
 
         case "bpm":
             ruleFunction = exports.ruleByBeatsPerMinute;
+            break;
 
         case "genre":
             ruleFunction = exports.ruleByGenre;
@@ -141,7 +142,7 @@ exports.ruleByBeatsPerMinute = function(track, beatsPerMinuteRuleData, operatorF
 {
     const trackBeatsPerMinute = dataRetrieval.getBeatsPerMinuteFromSavedTrack(track);
     return operatorFunction(trackBeatsPerMinute, beatsPerMinuteRuleData);
-}
+};
 
 // Generic Rule By X Functions
 function ruleBySongName(track, songNameRuleData, operatorFunction)

--- a/modules/smartPlaylistModules/rules.js
+++ b/modules/smartPlaylistModules/rules.js
@@ -56,27 +56,36 @@ function getRuleOperatorFunction(operator)
         case "notEqual":
             operatorFunction = operators.notEquals;
             break;
+
         case "greaterThan":
             operatorFunction = operators.greaterThan;
             break;
+
         case "greaterThanOrEqual":
             operatorFunction = operators.greaterThanOrEqualTo;
             break;
+
         case "lessThan":
             operatorFunction = operators.lessThan;
             break;
+
         case "lessThanOrEqual":
             operatorFunction = operators.lessThanOrEqualTo;
             break;
+
         case "contains":
             operatorFunction = operators.contains;
             break;
+
         case "doesNotContain":
             operatorFunction = operators.doesNotContain;
             break;
+
         case "equal":
-        default:
             operatorFunction = operators.equals;
+            break;
+
+        default:
             break;
     }
 
@@ -97,6 +106,9 @@ function getRuleFunction(ruleType)
             ruleFunction = ruleByAlbumName;
             break;
 
+        case "bpm":
+            ruleFunction = exports.ruleByBeatsPerMinute;
+
         case "genre":
             ruleFunction = exports.ruleByGenre;
             break;
@@ -106,15 +118,17 @@ function getRuleFunction(ruleType)
             break;
 
         case "song":
-        default:
             ruleFunction = ruleBySongName;
+            break;
+
+        default:
             break;
     }
 
     return ruleFunction;
 }
 
-// Specific Rule By X Functions
+// Special Rule By X Functions
 exports.ruleByGenre = function(track, genreNameRuleData, operatorFunction)
 {
     const trackGenres = dataRetrieval.getGenresFromSavedTrack(track);
@@ -123,6 +137,13 @@ exports.ruleByGenre = function(track, genreNameRuleData, operatorFunction)
     return operatorFunction(trackGenres, normalizedGenreNameRuleData);
 };
 
+exports.ruleByBeatsPerMinute = function(track, beatsPerMinuteRuleData, operatorFunction)
+{
+    const trackBeatsPerMinute = dataRetrieval.getBeatsPerMinuteFromSavedTrack(track);
+    return operatorFunction(trackBeatsPerMinute, beatsPerMinuteRuleData);
+}
+
+// Generic Rule By X Functions
 function ruleBySongName(track, songNameRuleData, operatorFunction)
 {
     const trackSongName = dataRetrieval.getTrackNameFromSavedTrack(track);

--- a/modules/smartPlaylistModules/specialRules.js
+++ b/modules/smartPlaylistModules/specialRules.js
@@ -15,6 +15,7 @@ const rules = require(path.join(smartPlaylistModulesPath, "rules.js"));
 
 // Default Constant Values
 const artistGenreRetrievalLimit = 50;
+const audioFeaturesRetrievalLimit = 100;
 
 // Special Rules Logic
 exports.getPlaylistSpecialRuleFlags = function(inputRules)
@@ -31,6 +32,11 @@ exports.getPlaylistSpecialRuleFlags = function(inputRules)
         if (inputRule.function === rules.ruleByGenre)
         {
             flags.add("genre");
+        }
+
+        if (inputRule.function === rules.ruleByBeatsPerMinute)
+        {
+            flags.add("audioFeatures");
         }
     }
 
@@ -120,6 +126,78 @@ exports.getArtistIdToGenreMap = async function(req, res, savedTracks, existingAr
         // If there is a problem with getting artist data, then a user's playlist request related to genre data cannot realistically succeed
         // Best to log the error and reject to avoid a situation where users are built an undesireable smart playlist
         logger.logError(`Failed to build artist to genres map: ${error.message}`);
+        return Promise.reject(error);
+    }
+};
+
+exports.getTrackIdToAudioFeaturesMap = async function(req, res, savedTracks, existingTrackIdToAudioFeaturesMap)
+{
+    try
+    {
+        // First, get a set of all unique track IDs that do not exist in our map already
+        const unmappedTrackIds = new Set();
+        for (const savedTrack of savedTracks)
+        {
+            // If we cannot find data about a track or ID, just skip the track
+            if (!savedTrack || !savedTrack.track || !savedTrack.track.id)
+            {
+                continue;
+            }
+
+            // Look to see that the ID is present and valid and does not already exist in our map
+            // If it does exist in the map, we can safely skip it (since we already know that song's audio features)
+            const trackId = savedTrack.track.id;
+            if (trackId && !existingTrackIdToAudioFeaturesMap.has(trackId))
+            {
+                unmappedTrackIds.add(trackId);
+            }
+        }
+
+        // If it turns out all of the tracks we have are already mapped, then we can just return the existing map
+        if (unmappedTrackIds.size <= 0)
+        {
+            return Promise.resolve(existingTrackIdToAudioFeaturesMap);
+        }
+
+        // With a set of unique unmapped track IDs, group them into chunks to get audio feature data for tracks in batches
+        const trackIds = Array.from(unmappedTrackIds);
+        const trackIdChunks = helperFunctions.getArrayChunks(trackIds, audioFeaturesRetrievalLimit);
+        const trackIdToAudioFeaturesMap = new Map();
+
+        for (const trackIdChunk of trackIdChunks)
+        {
+            // Call out to Spotify to get audio feature information for not already mapped tracks
+            req.query.trackIds = trackIdChunk;
+            const response = await spotifyClient.getAudioFeatures(req, res);
+            if (!response || !response.audioFeatures)
+            {
+                throw new Error("Failed to get valid audio features response data");
+            }
+
+            // Loop through all of the audio feature responses and store in the map (one audio feature object for each track)
+            for (const audioFeatures of response.audioFeatures)
+            {
+                if (!audioFeatures)
+                {
+                    continue;
+                }
+
+                // Add the audio features object into the map corresponding to the track ID
+                trackIdToAudioFeaturesMap.set(audioFeatures.id, audioFeatures);
+            }
+        }
+
+        // Finally, take the track IDs to audio features we found with this run
+        // Then add them to the existing map to return
+        const updatedTrackIdToAudioFeaturesMap = new Map([...existingTrackIdToAudioFeaturesMap, ...trackIdToAudioFeaturesMap]);
+        return Promise.resolve(updatedTrackIdToAudioFeaturesMap);
+    }
+    catch (error)
+    {
+        // If there is a problem with getting audio feature data,
+        // Then a user's playlist request related to audio feature data cannot realistically succeed
+        // Best to log the error and reject to avoid a situation where users are built an undesireable smart playlist
+        logger.logError(`Failed to build track to audio features map: ${error.message}`);
         return Promise.reject(error);
     }
 };

--- a/modules/spotifyClient.js
+++ b/modules/spotifyClient.js
@@ -21,7 +21,7 @@ const spotifyFollowingUriPath = "/following";
 const spotifyFollowersUriPath = "/followers";
 const spotifyPlaylistsUriPath = "/playlists";
 const spotifyArtistsUriPath = "/artists";
-const spotifyAudioFeaturesUriPath = "/audio-features"
+const spotifyAudioFeaturesUriPath = "/audio-features";
 
 // Spotify Constants
 const spotifyShortTerm = "short_term";
@@ -776,4 +776,4 @@ exports.getAudioFeatures = async function(req, res)
         logger.logError(`Failed to get audio features: ${error.message}`);
         return Promise.reject(error);
     }
-}
+};

--- a/modules/spotifyClient.js
+++ b/modules/spotifyClient.js
@@ -21,6 +21,7 @@ const spotifyFollowingUriPath = "/following";
 const spotifyFollowersUriPath = "/followers";
 const spotifyPlaylistsUriPath = "/playlists";
 const spotifyArtistsUriPath = "/artists";
+const spotifyAudioFeaturesUriPath = "/audio-features"
 
 // Spotify Constants
 const spotifyShortTerm = "short_term";
@@ -39,6 +40,7 @@ const trackAddToPlaylistLimitMax = 100;
 const tracksRequestLimitDefault = 10;
 const tracksRequestLimitMax = 50;
 const tracksPageNumberDefault = 1;
+const trackIdsLimitMax = 100;
 
 const artistTimeRangeDefault = spotifyLongTerm;
 const tracksTimeRangeDefault = spotifyLongTerm;
@@ -721,3 +723,57 @@ exports.getTopTracks = async function(req, res)
         return Promise.reject(error);
     }
 };
+
+exports.getAudioFeatures = async function(req, res)
+{
+    try
+    {
+        // Handle the case where the invalid parameters were passed to track IDs
+        const trackIds = req.query.trackIds;
+        if (!Array.isArray(trackIds))
+        {
+            throw new Error(`Invalid track IDs requested: "${trackIds}"`);
+        }
+
+        if (trackIds.length <= 0 || trackIds.length > trackIdsLimitMax)
+        {
+            throw new Error(`Invalid number of track IDs requested: ${trackIds.length}`);
+        }
+
+        const concatenatedTrackIds = trackIds
+            .filter(id => Boolean(id))
+            .join(",");
+
+        if (!concatenatedTrackIds)
+        {
+            throw new Error(`Invalid track IDs requested after concatenating: ${concatenatedTrackIds}`);
+        }
+
+        // Make the request to get each track's audio feature data
+        const requestData = {
+            ids: concatenatedTrackIds
+        };
+
+        const requestOptions = {
+            headers: {
+                Authorization: await authorize.getAccessToken(req, res)
+            }
+        };
+
+        const spotifyGetAudioFeaturesUri = `${spotifyBaseUri}${spotifyAudioFeaturesUriPath}`;
+        const spotifyGetAudioFeaturesRequestQuery = `?${querystring.stringify(requestData)}`;
+        const response = await axios.get(spotifyGetAudioFeaturesUri + spotifyGetAudioFeaturesRequestQuery, requestOptions);
+
+        // Extract only the data from the successful response that the user will care to see
+        const spotifyResponse = {
+            audioFeatures: response.data.audio_features
+        };
+
+        return Promise.resolve(spotifyResponse);
+    }
+    catch (error)
+    {
+        logger.logError(`Failed to get audio features: ${error.message}`);
+        return Promise.reject(error);
+    }
+}

--- a/public/scripts/createSmartPlaylist.js
+++ b/public/scripts/createSmartPlaylist.js
@@ -331,6 +331,10 @@ function addRuleFormFields()
     artistOptionRuleType.setAttribute("value", "artist");
     artistOptionRuleType.innerText = "Artist Name";
 
+    const beatsOptionRuleType = document.createElement("option");
+    beatsOptionRuleType.setAttribute("value", "bpm");
+    beatsOptionRuleType.innerText = "Beats Per Minute";
+
     const genreOptionRuleType = document.createElement("option");
     genreOptionRuleType.setAttribute("value", "genre");
     genreOptionRuleType.innerText = "Genre";
@@ -352,6 +356,7 @@ function addRuleFormFields()
     selectRuleType.appendChild(emptyOptionRuleType);
     selectRuleType.appendChild(albumOptionRuleType);
     selectRuleType.appendChild(artistOptionRuleType);
+    selectRuleType.appendChild(beatsOptionRuleType);
     selectRuleType.appendChild(genreOptionRuleType);
     selectRuleType.appendChild(yearOptionRuleType);
     selectRuleType.appendChild(songOptionRuleType);
@@ -572,7 +577,8 @@ function enableValidOperatorOptions()
             ruleOperatorAddSuccess = true;
             break;
 
-        case "number":
+        case "integer":
+        case "positiveInteger":
             addRuleOperatorOptionsForNumberDataType(ruleOperatorElement);
             ruleOperatorAddSuccess = true;
             break;
@@ -642,12 +648,21 @@ function enableValidRuleDataEntry()
     {
         case "string":
             ruleDataElement.setAttribute("type", "text");
+            ruleDataElement.removeAttribute("min");
             ruleDataElement.value = "";
             isRuleFieldTypeChangeSuccess = true;
             break;
 
-        case "number":
+        case "integer":
             ruleDataElement.setAttribute("type", "number");
+            ruleDataElement.removeAttribute("min");
+            ruleDataElement.value = "";
+            isRuleFieldTypeChangeSuccess = true;
+            break;
+
+        case "positiveInteger":
+            ruleDataElement.setAttribute("type", "number");
+            ruleDataElement.setAttribute("min", "0");
             ruleDataElement.value = "";
             isRuleFieldTypeChangeSuccess = true;
             break;
@@ -682,7 +697,10 @@ function getDataFieldType(ruleFieldValue)
             return "string";
 
         case "year":
-            return "number";
+            return "integer";
+
+        case "bpm":
+            return "positiveInteger";
 
         default:
             return null;


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
This is one of several PRs required to introduce audio features functionality to smart playlists.

This change in particular introduces a rule option that a user can specify, Beats Per Minute.  The value is generally a tempo and commonly abbreviated as BPM.

This change is a precursor to other feature additions where more audio feature functionality will be added as options for smart playlists.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested with different combinations of genre and beats per minute populated values.

Ensured that beats per minute value could not be negative on the front-end with form validation in place.  Also confirmed that operators were the mathematical numeric ones for BPM.

On the back-end, confirmed that audio features were retrieved correctly and enriching correctly onto the tracks object.  Also confirmed that beats per minute is one of these values and is correctly populated and compared.
