### PR TITLE
Replace Release Year with Release Date

### DIFF
--- a/modules/smartPlaylistModules/dataRetrieval.js
+++ b/modules/smartPlaylistModules/dataRetrieval.js
@@ -34,15 +34,6 @@ exports.getReleaseDateFromSavedTrack = function(savedTrack)
     return savedTrack.track.album.release_date;
 };
 
-exports.getReleaseYearFromSavedTrack = function(savedTrack)
-{
-    // The release year is usually YYYY-MM-DD but can optionally have month or day level precision
-    // Grab the first four characters present to get the year value only as it should always be present
-    const yearCharactersLength = 4;
-    return exports.getReleaseDateFromSavedTrack(savedTrack)
-        .substr(0, yearCharactersLength);
-};
-
 exports.getAddDateFromSavedTrack = function(savedTrack)
 {
     return savedTrack.added_at;

--- a/modules/smartPlaylistModules/rules.js
+++ b/modules/smartPlaylistModules/rules.js
@@ -8,6 +8,9 @@ const smartPlaylistModulesPath = __dirname;
 const dataRetrieval = require(path.join(smartPlaylistModulesPath, "dataRetrieval.js"));
 const operators = require(path.join(smartPlaylistModulesPath, "operators.js"));
 
+// Default Constant Values
+const noop = () => {};
+
 // Rules Logic
 exports.getPlaylistRules = function(req)
 {
@@ -28,7 +31,16 @@ exports.getPlaylistRules = function(req)
                 const ruleData = req.body[`playlistRuleData-${ruleNumber}`];
 
                 const ruleOperatorFunction = getRuleOperatorFunction(ruleOperator);
+                if (ruleOperatorFunction === noop)
+                {
+                    throw new Error("Failed to find valid rule operator function");
+                }
+
                 const ruleFunction = getRuleFunction(ruleType);
+                if (ruleFunction === noop)
+                {
+                    throw new Error("Failed to find valid rule by function");
+                }
 
                 const ruleFromParameters =
                 {
@@ -49,7 +61,7 @@ exports.getPlaylistRules = function(req)
 // Local Helper Functions
 function getRuleOperatorFunction(operator)
 {
-    let operatorFunction = () => {};
+    let operatorFunction = noop;
 
     switch (operator)
     {
@@ -94,7 +106,7 @@ function getRuleOperatorFunction(operator)
 
 function getRuleFunction(ruleType)
 {
-    let ruleFunction = () => {};
+    let ruleFunction = noop;
 
     switch (ruleType)
     {
@@ -114,8 +126,8 @@ function getRuleFunction(ruleType)
             ruleFunction = exports.ruleByGenre;
             break;
 
-        case "year":
-            ruleFunction = ruleByReleaseYear;
+        case "releaseDate":
+            ruleFunction = ruleByReleaseDate;
             break;
 
         case "song":
@@ -161,10 +173,10 @@ function ruleByAlbumName(track, albumNameRuleData, operatorFunction)
     return operatorFunction(trackAlbumName, normalizedAlbumNameRuleData);
 }
 
-function ruleByReleaseYear(track, releaseYearRuleData, operatorFunction)
+function ruleByReleaseDate(track, releaseDateRuleData, operatorFunction)
 {
-    const trackReleaseYear = dataRetrieval.getReleaseYearFromSavedTrack(track);
-    return operatorFunction(trackReleaseYear, releaseYearRuleData);
+    const trackReleaseDate = dataRetrieval.getReleaseDateFromSavedTrack(track);
+    return operatorFunction(trackReleaseDate, releaseDateRuleData);
 }
 
 function ruleByArtistName(track, artistNameRuleData, operatorFunction)

--- a/public/scripts/createSmartPlaylist.js
+++ b/public/scripts/createSmartPlaylist.js
@@ -339,9 +339,9 @@ function addRuleFormFields()
     genreOptionRuleType.setAttribute("value", "genre");
     genreOptionRuleType.innerText = "Genre";
 
-    const yearOptionRuleType = document.createElement("option");
-    yearOptionRuleType.setAttribute("value", "year");
-    yearOptionRuleType.innerText = "Release Year";
+    const releaseDateOptionRuleType = document.createElement("option");
+    releaseDateOptionRuleType.setAttribute("value", "releaseDate");
+    releaseDateOptionRuleType.innerText = "Release Date";
 
     const songOptionRuleType = document.createElement("option");
     songOptionRuleType.setAttribute("value", "song");
@@ -358,7 +358,7 @@ function addRuleFormFields()
     selectRuleType.appendChild(artistOptionRuleType);
     selectRuleType.appendChild(beatsOptionRuleType);
     selectRuleType.appendChild(genreOptionRuleType);
-    selectRuleType.appendChild(yearOptionRuleType);
+    selectRuleType.appendChild(releaseDateOptionRuleType);
     selectRuleType.appendChild(songOptionRuleType);
 
     const ruleTypeDiv = document.createElement("div");
@@ -577,7 +577,11 @@ function enableValidOperatorOptions()
             ruleOperatorAddSuccess = true;
             break;
 
-        case "integer":
+        case "date":
+            addRuleOperatorOptionsForDateDataType(ruleOperatorElement);
+            ruleOperatorAddSuccess = true;
+            break;
+
         case "positiveInteger":
             addRuleOperatorOptionsForNumberDataType(ruleOperatorElement);
             ruleOperatorAddSuccess = true;
@@ -653,8 +657,8 @@ function enableValidRuleDataEntry()
             isRuleFieldTypeChangeSuccess = true;
             break;
 
-        case "integer":
-            ruleDataElement.setAttribute("type", "number");
+        case "date":
+            ruleDataElement.setAttribute("type", "date");
             ruleDataElement.removeAttribute("min");
             ruleDataElement.value = "";
             isRuleFieldTypeChangeSuccess = true;
@@ -696,8 +700,8 @@ function getDataFieldType(ruleFieldValue)
         case "song":
             return "string";
 
-        case "year":
-            return "integer";
+        case "releaseDate":
+            return "date";
 
         case "bpm":
             return "positiveInteger";
@@ -771,6 +775,48 @@ function addRuleOperatorOptionsForNumberDataType(ruleOperatorElement)
     const lessThanOrEqualToOptionRuleOperator = document.createElement("option");
     lessThanOrEqualToOptionRuleOperator.setAttribute("value", "lessThanOrEqual");
     lessThanOrEqualToOptionRuleOperator.innerText = "is less than or equal to";
+
+    ruleOperatorElement.appendChild(emptyOptionRuleOperator);
+    ruleOperatorElement.appendChild(equalOptionRuleOperator);
+    ruleOperatorElement.appendChild(notEqualOptionRuleOperator);
+    ruleOperatorElement.appendChild(greaterThanOptionRuleOperator);
+    ruleOperatorElement.appendChild(greaterThanOrEqualToOptionRuleOperator);
+    ruleOperatorElement.appendChild(lessThanOptionRuleOperator);
+    ruleOperatorElement.appendChild(lessThanOrEqualToOptionRuleOperator);
+}
+
+function addRuleOperatorOptionsForDateDataType(ruleOperatorElement)
+{
+    const emptyOptionRuleOperator = document.createElement("option");
+    emptyOptionRuleOperator.setAttribute("value", "");
+    emptyOptionRuleOperator.setAttribute("selected", "");
+    emptyOptionRuleOperator.setAttribute("disabled", "");
+    emptyOptionRuleOperator.setAttribute("hidden", "");
+    emptyOptionRuleOperator.innerText = "Select an Operator";
+
+    const equalOptionRuleOperator = document.createElement("option");
+    equalOptionRuleOperator.setAttribute("value", "equal");
+    equalOptionRuleOperator.innerText = "is";
+
+    const notEqualOptionRuleOperator = document.createElement("option");
+    notEqualOptionRuleOperator.setAttribute("value", "notEqual");
+    notEqualOptionRuleOperator.innerText = "is not";
+
+    const greaterThanOptionRuleOperator = document.createElement("option");
+    greaterThanOptionRuleOperator.setAttribute("value", "greaterThan");
+    greaterThanOptionRuleOperator.innerText = "is after";
+
+    const greaterThanOrEqualToOptionRuleOperator = document.createElement("option");
+    greaterThanOrEqualToOptionRuleOperator.setAttribute("value", "greaterThanOrEqual");
+    greaterThanOrEqualToOptionRuleOperator.innerText = "is on or after";
+
+    const lessThanOptionRuleOperator = document.createElement("option");
+    lessThanOptionRuleOperator.setAttribute("value", "lessThan");
+    lessThanOptionRuleOperator.innerText = "is before";
+
+    const lessThanOrEqualToOptionRuleOperator = document.createElement("option");
+    lessThanOrEqualToOptionRuleOperator.setAttribute("value", "lessThanOrEqual");
+    lessThanOrEqualToOptionRuleOperator.innerText = "is on or before";
 
     ruleOperatorElement.appendChild(emptyOptionRuleOperator);
     ruleOperatorElement.appendChild(equalOptionRuleOperator);


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
This change adjusts a smart playlist rule input field for release year, which was a number type, to release date, which is a date type.

This should allow users a better interface for entering and dealing with release date rules, including by using date pickers rather than a number type input.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested with various date inputs and the parameters to ensure the date picker and values (and their operators) are working properly.

Operator functions work based on a string comparison.  Date picker chooses dates of the form "YYYY-MM-DD" and then compares them to Spotify date strings which are either "YYYY", "YYYY-MM", "YYYY-MM-DD" depending on granularity.  Either way, the equality and inequality properties are working even if it is with a string comparison operation.

