### PR TITLE
Implement Speechiness Audio Feature Rule

### DIFF
--- a/modules/smartPlaylistModules/dataRetrieval.js
+++ b/modules/smartPlaylistModules/dataRetrieval.js
@@ -92,6 +92,11 @@ exports.getLivenessFromSavedTrack = function(savedTrack)
     return savedTrack.track.audio_features.liveness;
 };
 
+exports.getSpeechinessFromSavedTrack = function(savedTrack)
+{
+    return savedTrack.track.audio_features.speechiness;
+};
+
 // Retrieve Native Data from Artist Object
 exports.getArtistNameFromArtist = function(artist)
 {

--- a/modules/smartPlaylistModules/rules.js
+++ b/modules/smartPlaylistModules/rules.js
@@ -170,6 +170,10 @@ function getRuleFunction(ruleType)
             ruleFunction = ruleBySongName;
             break;
 
+        case "speechiness":
+            ruleFunction = exports.ruleBySpeechiness;
+            break;
+
         case "tempo":
             ruleFunction = exports.ruleByBeatsPerMinute;
             break;
@@ -245,6 +249,12 @@ exports.ruleByLiveness = function(track, livenessRuleData, operatorFunction)
 {
     const trackLiveness = dataRetrieval.getLivenessFromSavedTrack(track);
     return operatorFunction(trackLiveness, livenessRuleData);
+};
+
+exports.ruleBySpeechiness = function(track, speechinessRuleData, operatorFunction)
+{
+    const trackSpeechiness = dataRetrieval.getSpeechinessFromSavedTrack(track);
+    return operatorFunction(trackSpeechiness, speechinessRuleData);
 };
 
 // Generic Rule By X Functions

--- a/modules/smartPlaylistModules/specialRules.js
+++ b/modules/smartPlaylistModules/specialRules.js
@@ -44,7 +44,8 @@ exports.getPlaylistSpecialRuleFlags = function(inputRules)
             inputRuleFunction === rules.ruleByDanceability ||
             inputRuleFunction === rules.ruleByEnergy ||
             inputRuleFunction === rules.ruleByInstrumentalness ||
-            inputRuleFunction === rules.ruleByLiveness;
+            inputRuleFunction === rules.ruleByLiveness ||
+            inputRuleFunction === rules.ruleBySpeechiness;
 
         if (isAudioFeaturesRule)
         {

--- a/public/scripts/createSmartPlaylist.js
+++ b/public/scripts/createSmartPlaylist.js
@@ -363,6 +363,10 @@ function addRuleFormFields()
     releaseDateOptionRuleType.setAttribute("value", "releaseDate");
     releaseDateOptionRuleType.innerText = "Release Date";
 
+    const speechinessRuleType = document.createElement("option");
+    speechinessRuleType.setAttribute("value", "speechiness");
+    speechinessRuleType.innerText = "Speechiness";
+
     const songDurationOptionRuleType = document.createElement("option");
     songDurationOptionRuleType.setAttribute("value", "duration");
     songDurationOptionRuleType.innerText = "Song Length";
@@ -392,6 +396,7 @@ function addRuleFormFields()
     selectRuleType.appendChild(livenessRuleType);
     selectRuleType.appendChild(loudnessOptionRuleType);
     selectRuleType.appendChild(releaseDateOptionRuleType);
+    selectRuleType.appendChild(speechinessRuleType);
     selectRuleType.appendChild(songDurationOptionRuleType);
     selectRuleType.appendChild(songOptionRuleType);
     selectRuleType.appendChild(tempoOptionRuleType);
@@ -843,6 +848,7 @@ function getDataFieldType(ruleFieldValue)
         case "energy":
         case "instrumentalness":
         case "liveness":
+        case "speechiness":
             return "percentage";
 
         default:
@@ -868,6 +874,7 @@ function getDataFieldUnit(ruleFieldValue)
         case "energy":
         case "instrumentalness":
         case "liveness":
+        case "speechiness":
             return "Percent";
 
         case "album":


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
This change in particular introduces functionality for "speechiness" for smart playlist rules.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested by generating several playlists using "Speechiness" as the input.  Tested the front-end to ensure the value is a percentage made clear to the user.

Also tested with percentages in the transition between front and back-end to ensure they are converted correctly to decimals for comparison with Spotify data.

#### Additional Notes
<!-- This section can optionally be included if there is anything else in particular to note about this PR, like surrounding context, the issues it uncovered or resolved, etc. -->
More details from Spotify here - https://developer.spotify.com/documentation/web-api/reference/#/operations/get-audio-features

Quoting for posterity:

> speechiness - number \<float>
>
> Speechiness detects the presence of spoken words in a track. The more exclusively speech-like the recording (e.g. talk show, audio book, poetry), the closer to 1.0 the attribute value. Values above 0.66 describe tracks that are probably made entirely of spoken words. Values between 0.33 and 0.66 describe tracks that may contain both music and speech, either in sections or layered, including such cases as rap music. Values below 0.33 most likely represent music and other non-speech-like tracks.
>
> [Bounds:] 0 <= x <= 1
