### PR TITLE
Implement Valence (Positivity) Audio Feature Rule

### DIFF
--- a/modules/smartPlaylistModules/dataRetrieval.js
+++ b/modules/smartPlaylistModules/dataRetrieval.js
@@ -97,6 +97,11 @@ exports.getSpeechinessFromSavedTrack = function(savedTrack)
     return savedTrack.track.audio_features.speechiness;
 };
 
+exports.getValenceFromSavedTrack = function(savedTrack)
+{
+    return savedTrack.track.audio_features.valence;
+};
+
 // Retrieve Native Data from Artist Object
 exports.getArtistNameFromArtist = function(artist)
 {

--- a/modules/smartPlaylistModules/rules.js
+++ b/modules/smartPlaylistModules/rules.js
@@ -178,6 +178,10 @@ function getRuleFunction(ruleType)
             ruleFunction = exports.ruleByBeatsPerMinute;
             break;
 
+        case "valence":
+            ruleFunction = exports.ruleByValence;
+            break;
+
         default:
             break;
     }
@@ -255,6 +259,12 @@ exports.ruleBySpeechiness = function(track, speechinessRuleData, operatorFunctio
 {
     const trackSpeechiness = dataRetrieval.getSpeechinessFromSavedTrack(track);
     return operatorFunction(trackSpeechiness, speechinessRuleData);
+};
+
+exports.ruleByValence = function(track, valenceRuleData, operatorFunction)
+{
+    const trackValence = dataRetrieval.getValenceFromSavedTrack(track);
+    return operatorFunction(trackValence, valenceRuleData);
 };
 
 // Generic Rule By X Functions

--- a/modules/smartPlaylistModules/specialRules.js
+++ b/modules/smartPlaylistModules/specialRules.js
@@ -45,7 +45,8 @@ exports.getPlaylistSpecialRuleFlags = function(inputRules)
             inputRuleFunction === rules.ruleByEnergy ||
             inputRuleFunction === rules.ruleByInstrumentalness ||
             inputRuleFunction === rules.ruleByLiveness ||
-            inputRuleFunction === rules.ruleBySpeechiness;
+            inputRuleFunction === rules.ruleBySpeechiness ||
+            inputRuleFunction === rules.ruleByValence;
 
         if (isAudioFeaturesRule)
         {

--- a/public/scripts/createSmartPlaylist.js
+++ b/public/scripts/createSmartPlaylist.js
@@ -359,6 +359,10 @@ function addRuleFormFields()
     loudnessOptionRuleType.setAttribute("value", "loudness");
     loudnessOptionRuleType.innerText = "Loudness";
 
+    const positivityOptionRuleType = document.createElement("option");
+    positivityOptionRuleType.setAttribute("value", "valence");
+    positivityOptionRuleType.innerText = "Positivity";
+
     const releaseDateOptionRuleType = document.createElement("option");
     releaseDateOptionRuleType.setAttribute("value", "releaseDate");
     releaseDateOptionRuleType.innerText = "Release Date";
@@ -395,6 +399,7 @@ function addRuleFormFields()
     selectRuleType.appendChild(instrumentalnessRuleType);
     selectRuleType.appendChild(livenessRuleType);
     selectRuleType.appendChild(loudnessOptionRuleType);
+    selectRuleType.appendChild(positivityOptionRuleType);
     selectRuleType.appendChild(releaseDateOptionRuleType);
     selectRuleType.appendChild(speechinessRuleType);
     selectRuleType.appendChild(songDurationOptionRuleType);
@@ -849,6 +854,7 @@ function getDataFieldType(ruleFieldValue)
         case "instrumentalness":
         case "liveness":
         case "speechiness":
+        case "valence":
             return "percentage";
 
         default:
@@ -875,6 +881,7 @@ function getDataFieldUnit(ruleFieldValue)
         case "instrumentalness":
         case "liveness":
         case "speechiness":
+        case "valence":
             return "Percent";
 
         case "album":


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
This change in particular introduces functionality for "valence" or "positivity" for smart playlist rules.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested by generating several playlists using "Valence" as the input.  Tested the front-end to ensure the value is a percentage made clear to the user.

Also tested with percentages in the transition between front and back-end to ensure they are converted correctly to decimals for comparison with Spotify data.

#### Additional Notes
<!-- This section can optionally be included if there is anything else in particular to note about this PR, like surrounding context, the issues it uncovered or resolved, etc. -->
More details from Spotify here - https://developer.spotify.com/documentation/web-api/reference/#/operations/get-audio-features

Quoting for posterity:

> valence - number \<float>
>
> A measure from 0.0 to 1.0 describing the musical positiveness conveyed by a track. Tracks with high valence sound more positive (e.g. happy, cheerful, euphoric), while tracks with low valence sound more negative (e.g. sad, depressed, angry).
>
> [Bounds:] 0 <= x <= 1
