### PR TITLE
Fix Script Content Security Policy Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ const helmetConfiguration = {
                 "data:",
                 "*.scdn.co"
             ],
-            "script-src-elem": [
+            "script-src": [
                 "'self'",
                 "'unsafe-inline'",
                 "stackpath.bootstrapcdn.com",


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
When opening Firefox and viewing the JAMMS Home page, no album images loaded.  The console was filled with script content security policy errors.

This was because Firefox (and Safari for that matter) does not recognize the previously used `script-src-elem` value for content security policy - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem#browser_compatibility

However, these browsers have listed internal support and "unknown" external support for the `script-src` value - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#browser_compatibility

Through testing, I have determined that the browsers listed here (particularly Firefox and Opera) do not have issues loading external scripts using this policy, however I have not tested with Safari (it is only available on Mac hardware, which I do not have).

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested with Opera, FireFox, Chrome, and Edge.  Unable to test with Safari.  Already incompatible with IE, so no update there.