### PR TITLE
Replace Header and Footer with Navigation Bars

### DIFF
--- a/views/layout.vash
+++ b/views/layout.vash
@@ -32,26 +32,33 @@
 
   <script defer src="scripts/layout.js"></script>
 
-  <header class="card-header text-center mb-2">
-    <div class="row">
-      @if(!model.isAwaitingLogin && !model.isLoginError)
-      {
-        <div class="col">
-          <a id="homeButton" href="/home" role="button" class="btn btn-info btn-sm">Home</a>
-        </div>
-      }
+  <header class="mb-2">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <a class="navbar-brand nav-link font-weight-bold" href="/">JAMMS</a>
+      <ul class="navbar-nav mr-auto">
+        @if (!model.isAwaitingLogin && !model.isLoginError)
+        {
+          <li class="nav-item">
+            <a class="nav-link" href="/home">Home</a>
+          </li>
+        }
+        else
+        {
+          <li class="nav-item">
+            <a class="nav-link" href="/">Home</a>
+          </li>
+        }
+      </ul>
 
-      <div class="col">
-        <h5 class="my-0">JAMMS</h5>
-      </div>
-
-      @if(!model.isAwaitingLogin && !model.isLoginError)
+      @if (!model.isAwaitingLogin && !model.isLoginError)
       {
-        <div class="col">
-            <a id="logOutButton" href="/logout" role="button" class="btn btn-info btn-sm">Log Out</a>
-        </div>
+        <a id="logOutButton" href="/logout" role="button" class="nav-link btn btn-info btn-sm">Log Out</a>
       }
-    </div>
+      else
+      {
+        <a id="loginButton" href="/login" role="button" class="nav-link btn btn-info btn-sm">Log In</a>
+      }
+    </nav>
   </header>
 
   <main role="main" class="flex-shrink-0">

--- a/views/layout.vash
+++ b/views/layout.vash
@@ -33,7 +33,7 @@
   <script defer src="scripts/layout.js"></script>
 
   <header class="card-header p-0 mb-2">
-    <nav class="navbar navbar-expand-lg navbar-light">
+    <nav class="navbar navbar-expand navbar-light">
       <div class="container">
         <a class="navbar-brand nav-link font-weight-bold" href="/">JAMMS</a>
         <ul class="navbar-nav mr-auto">
@@ -46,9 +46,6 @@
             {
               <a class="nav-link" href="/">Home</a>
             }
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="@html.raw('mailto:admin@jamms.app')">Contact</a>
           </li>
         </ul>
 
@@ -70,21 +67,27 @@
     </div>
   </main>
 
-  <footer class="footer card-footer p-0 mt-auto">
+  <footer class="footer card-footer p-0 mt-auto small">
     <nav class="navbar navbar-expand navbar-light">
       <div class="container">
         <ul class="navbar-nav">
-          <li class="nav-item">
-            <span class="navbar-text">Copyright © 2020</span>
+          <li class="nav-item mr-2">
+            <span class="navbar-text">&copy; 2020</span>
           </li>
-          <li class="nav-item">
-            <a class="nav-link" href="http://iansantagata.com">Creator</a>
-          </li>
+          <span class="navbar-text">•</span>
           <li class="nav-item">
             <a class="nav-link" href="@html.raw('mailto:admin@jamms.app')">Contact</a>
           </li>
+        </ul>
+        <!-- Musical Bridged 8th Notes HTML Entity Code -->
+        <span class="navbar-text">&#9835;</span>
+        <ul class="navbar-nav">
           <li class="nav-item">
             <a class="nav-link" href="https://github.com/iansantagata/jamms">Source</a>
+          </li>
+          <span class="navbar-text">&bull;</span>
+          <li class="nav-item">
+            <a class="nav-link" href="http://iansantagata.com">Author</a>
           </li>
         </ul>
       </div>

--- a/views/layout.vash
+++ b/views/layout.vash
@@ -34,30 +34,33 @@
 
   <header class="card-header p-0 mb-2">
     <nav class="navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand nav-link font-weight-bold" href="/">JAMMS</a>
-      <ul class="navbar-nav mr-auto">
+      <div class="container">
+        <a class="navbar-brand nav-link font-weight-bold" href="/">JAMMS</a>
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item">
+            @if (!model.isAwaitingLogin && !model.isLoginError)
+            {
+              <a class="nav-link" href="/home">Home</a>
+            }
+            else
+            {
+              <a class="nav-link" href="/">Home</a>
+            }
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="@html.raw('mailto:admin@jamms.app')">Contact</a>
+          </li>
+        </ul>
+
         @if (!model.isAwaitingLogin && !model.isLoginError)
         {
-          <li class="nav-item">
-            <a class="nav-link" href="/home">Home</a>
-          </li>
+          <a id="logOutButton" href="/logout" role="button" class="nav-link btn btn-info btn-sm">Log Out</a>
         }
         else
         {
-          <li class="nav-item">
-            <a class="nav-link" href="/">Home</a>
-          </li>
+          <a id="loginButton" href="/login" role="button" class="nav-link btn btn-info btn-sm">Log In</a>
         }
-      </ul>
-
-      @if (!model.isAwaitingLogin && !model.isLoginError)
-      {
-        <a id="logOutButton" href="/logout" role="button" class="nav-link btn btn-info btn-sm">Log Out</a>
-      }
-      else
-      {
-        <a id="loginButton" href="/login" role="button" class="nav-link btn btn-info btn-sm">Log In</a>
-      }
+      </div>
     </nav>
   </header>
 
@@ -67,20 +70,25 @@
     </div>
   </main>
 
-  <footer class="footer mt-auto">
-    <div class="card-footer text-center">
-      <div class="row">
-        <div class="col">
-          <p class="my-0">JAMMS is <a href="https://github.com/iansantagata/jamms">open source</a>!</p>
-        </div>
-        <div class="col">
-          <p class="my-0">Created by <a href="http://iansantagata.com">Ian Santagata</a></p>
-        </div>
-        <div class="col">
-          <p class="my-0"><a href="@html.raw('mailto:admin@jamms.app')">Contact E-Mail</a></p>
-        </div>
+  <footer class="footer card-footer p-0 mt-auto">
+    <nav class="navbar navbar-expand navbar-light">
+      <div class="container">
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <span class="navbar-text">Copyright © 2020</span>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="http://iansantagata.com">Creator</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="@html.raw('mailto:admin@jamms.app')">Contact</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://github.com/iansantagata/jamms">Source</a>
+          </li>
+        </ul>
       </div>
-    </div>
+    </nav>
   </footer>
 
 </body>

--- a/views/layout.vash
+++ b/views/layout.vash
@@ -32,8 +32,8 @@
 
   <script defer src="scripts/layout.js"></script>
 
-  <header class="mb-2">
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <header class="card-header p-0 mb-2">
+    <nav class="navbar navbar-expand-lg navbar-light">
       <a class="navbar-brand nav-link font-weight-bold" href="/">JAMMS</a>
       <ul class="navbar-nav mr-auto">
         @if (!model.isAwaitingLogin && !model.isLoginError)


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
This change addresses #21.

The goal of this change is to replace the clunky header and footers which were used for navigation previously with standard navigation bars.

It makes the design of the site look more standardized, allow users to easier navigate across the sites pages, and sets up the header to be able to support additional links, in order to clean up pages, like all the playlist page functionality.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested in Opera and in Firefox.  Ensured that headers and footers via nav bars appeared as intended, were formatted and styled appropriately, and were visible to the user.

Also confirmed that the log out or log in button was drawn appropriately depending on user login state.

#### Additional Notes
<!-- This section can optionally be included if there is anything else in particular to note about this PR, like surrounding context, the issues it uncovered or resolved, etc. -->
This implementation idea was to keep metadata navigation about the site (like it's source code since it is open source, a contact section, copyright, and author information) separate from site navigation.  Site navigation belongs in the header while metadata navigation belongs in the footer.

The one exception to this may be `Contact`.  Future iterations may route users to a contact page which could theoretically be included in both the header and footer for visibility.
