### PR TITLE
Make Tables More Mobile Friendly

### DIFF
--- a/public/scripts/createSmartPlaylist.js
+++ b/public/scripts/createSmartPlaylist.js
@@ -265,12 +265,15 @@ function displaySmartPlaylistPreview(data)
     buttonDivElement.appendChild(buttonElement);
 
     // Mark the table as responsive and shove the data inside of it
+    const tableContainerElement = document.createElement("div");
+    tableContainerElement.setAttribute("class", "table-responsive");
+    tableContainerElement.appendChild(tableElement);
+
     const previewContainerElement = document.createElement("div");
     previewContainerElement.setAttribute("id", "previewContainer");
-    previewContainerElement.setAttribute("class", "table-responsive");
     previewContainerElement.appendChild(headerElement);
     previewContainerElement.appendChild(alertDivElement);
-    previewContainerElement.appendChild(tableElement);
+    previewContainerElement.appendChild(tableContainerElement);
     previewContainerElement.appendChild(buttonDivElement);
 
     // Finally, append all of this new content onto the end of the existing form

--- a/public/scripts/createSmartPlaylist.js
+++ b/public/scripts/createSmartPlaylist.js
@@ -246,7 +246,7 @@ function displaySmartPlaylistPreview(data)
 
     // Create the table element where the data will reside
     const tableElement = document.createElement("table");
-    tableElement.setAttribute("class", "table table-striped table-sm table-hover");
+    tableElement.setAttribute("class", "table table-striped table-sm table-hover small");
     tableElement.appendChild(tableHeadElement);
     tableElement.appendChild(tableBodyElement);
 

--- a/views/home.vash
+++ b/views/home.vash
@@ -11,7 +11,7 @@
       <p>Some of your playlists are listed below!</p>
 
       <div id="playlists" class="table-responsive">
-        <table class="table table-striped table-sm table-hover">
+        <table class="table table-striped table-sm table-hover small">
           <thead>
             <tr>
               <th scope="col" class="align-middle">Playlist #</th>
@@ -38,7 +38,9 @@
                   @{
                     var viewPlaylistLinkId = "viewPlaylistLink-" + playlistCount;
                   }
-                  <a id="@viewPlaylistLinkId" href="/playlist?playlistId=@item.id" role="button" class="btn btn-outline-info btn-sm">View Playlist</a>
+                  <a id="@viewPlaylistLinkId" href="/playlist?playlistId=@item.id" role="button" class="btn btn-outline-info btn-sm">
+                    View
+                  </a>
                 </td>
                 <td class="align-middle col-md-2">
                   @{
@@ -85,7 +87,7 @@
       <h6 class="my-4">Your Top Tracks</h6>
 
       <div id="songs" class="table-responsive">
-        <table class="table table-striped table-sm table-hover">
+        <table class="table table-striped table-sm table-hover small">
           <thead>
             <tr>
               <th scope="col" class="align-middle">Track #</th>
@@ -158,7 +160,7 @@
       <h6 class="my-4">Your Top Artists</h6>
 
       <div id="artists" class="table-responsive">
-        <table class="table table-striped table-sm table-hover">
+        <table class="table table-striped table-sm table-hover small">
           <thead>
             <tr>
               <th scope="col" class="align-middle">Artist #</th>

--- a/views/viewPlaylists.vash
+++ b/views/viewPlaylists.vash
@@ -27,7 +27,7 @@
     @if(model.playlists.length > 0)
     {
       <div id="playlists" class="table-responsive">
-        <table class="table table-striped table-sm table-hover">
+        <table class="table table-striped table-sm table-hover small">
           <thead>
             <tr>
               <th scope="col" class="align-middle">Playlist #</th>
@@ -54,7 +54,9 @@
                   @{
                     var viewPlaylistLinkId = "viewPlaylistLink-" + playlistCount;
                   }
-                  <a id="@viewPlaylistLinkId" href="/playlist?playlistId=@item.id" role="button" class="btn btn-outline-info btn-sm">View Playlist</a>
+                  <a id="@viewPlaylistLinkId" href="/playlist?playlistId=@item.id" role="button" class="btn btn-outline-info btn-sm">
+                    View
+                  </a>
                 </td>
                 <td class="align-middle col-md-2">
                   @{


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
Tables are a little difficult to read currently on mobile.  There is a lot of white space and data to show the user.

Aside from addressing the issues with images, the next best thing is to address the white space and font size.  By decreasing the font size, this allows for less white space on mobile, does not hinder readability meaningfully, and allows for better handling of the site at its smallest horizontal widths.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested using Opera on phone mode at its slimmest.  Tables generally fit the screen, with the exception of some older and smaller resolution devices (smart phones).