### PR TITLE
Only Run Pre- and Post-Install in Non-Production Environments

### DIFF
--- a/build/skipInProduction.sh
+++ b/build/skipInProduction.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+shopt -s nocasematch
+
+if [[ -n $NODE_ENV || $NODE_ENV == "" || $NODE_ENV != "production" ]]
+then
+    echo "Detected development environment: Executing next task."
+    exit 1;
+fi
+
+echo "Detected production environment: Skipping next task."
+exit 0;

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lintvash": "linthtml **/*.vash",
     "lint": "npm run lintjs && npm run linthtml && npm run lintvash",
     "lintfix": "eslint . --fix --ignore-path .gitignore",
-    "preinstall": "grunt clean",
-    "postinstall": "grunt copy"
+    "preinstall": "sh ./build/skipInProduction.sh || grunt clean",
+    "postinstall": "sh ./build/skipInProduction.sh || grunt copy"
   },
   "dependencies": {
     "axios": "^0.21.4",


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
This change is a follow-up bug fix to the previous change here - https://github.com/iansantagata/jamms/pull/106

In particular, introducing Grunt as part of `npm install` process to run with the `preinstall` and `postinstall` steps fails when running `npm` install in Production.

This can be seen as a GitHub Action failure here on the Continuous Deployment action for the `master` build of the above PR's merge - https://github.com/iansantagata/jamms/runs/4094900184?check_suite_focus=true#step:8:30

Locally, this functions as desired and expected for developers to utilize and populate files in the correct locations for debuging.  So development environments need not change.  However, the Production environment will not have Grunt installed (it is a development dependency only) and all files will already be in the correct location and synced over based on previous steps in the same GitHub Action.

Therefore, the solution here is to introduce functionality to only run these `preinstall` and `postinstall` steps in non-Production environments.  

This change sets out to achieve this with a fairly light-weight shell script.  The script exits with a status code that is meant to be chained with `script.sh || otherCommand`.  If the script returns a success exit code (`0`), then `otherCommand` will not be run because of lazy evaluation.  If the script returns a failure exit code (`1`), then `otherCommand` will be run since the first command evaluated to a falsy value.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested locally, running `npm install` to ensure that development environments behave the same way as they do now.

Fastest testing for Production is iterating with the GitHub action to see if this solves the issue.
