### PR TITLE
Handle Contact Form Bot Activity

### DIFF
--- a/modules/requestModules/help.js
+++ b/modules/requestModules/help.js
@@ -10,7 +10,7 @@ const loginUtils = require(path.join(utilityModulesPath, "loginUtils.js"));
 const errorUtils = require(path.join(utilityModulesPath, "errorUtils.js"));
 const emailUtils = require(path.join(utilityModulesPath, "emailUtils.js"));
 const environment = require(path.join(utilityModulesPath, "environment.js"));
-const cookie = require(path.join(utilityModulesPath, "cookie.js"))
+const cookie = require(path.join(utilityModulesPath, "cookie.js"));
 
 // Default Constant Values
 const successCode = 200;
@@ -22,7 +22,7 @@ const doNotReplyUserName = "JAMMS.app";
 const adminEmail = "admin@jamms.app";
 const confirmationEmailSubject = "Contact Confirmation - JAMMS.app";
 
-const pageLoadKey = "PageLoadTime"
+const pageLoadKey = "PageLoadTime";
 const pageLoadToFormSubmitHumanLowerLimitInMsec = 5000;
 
 // Help Logic
@@ -38,7 +38,7 @@ exports.getHelpPage = async function(req, res, next)
         };
 
         // Set a cookie with a timestamp of when the help page was last loaded
-        pageLoadTimeStamp = Date.now();
+        const pageLoadTimeStamp = Date.now();
         cookie.setCookie(req, res, pageLoadKey, pageLoadTimeStamp); // Session cookie (no explicit expiration)
 
         // Render the help page that the user can interact with
@@ -60,7 +60,7 @@ exports.sendContactEmail = async function(req, res)
         // Page load time to form submit time should be over a reasonable amount (a few seconds) for a human
         const pageLoadTimeStamp = await cookie.getCookie(req, pageLoadKey);
 
-        formSubmitTimeStamp = Date.now();
+        const formSubmitTimeStamp = Date.now();
         const sendEmail = formSubmitTimeStamp - pageLoadTimeStamp >= pageLoadToFormSubmitHumanLowerLimitInMsec;
         if (sendEmail)
         {

--- a/modules/requestModules/help.js
+++ b/modules/requestModules/help.js
@@ -10,6 +10,7 @@ const loginUtils = require(path.join(utilityModulesPath, "loginUtils.js"));
 const errorUtils = require(path.join(utilityModulesPath, "errorUtils.js"));
 const emailUtils = require(path.join(utilityModulesPath, "emailUtils.js"));
 const environment = require(path.join(utilityModulesPath, "environment.js"));
+const cookie = require(path.join(utilityModulesPath, "cookie.js"))
 
 // Default Constant Values
 const successCode = 200;
@@ -20,6 +21,9 @@ const doNotReplyUserName = "JAMMS.app";
 
 const adminEmail = "admin@jamms.app";
 const confirmationEmailSubject = "Contact Confirmation - JAMMS.app";
+
+const pageLoadKey = "PageLoadTime"
+const pageLoadToFormSubmitHumanLowerLimitInMsec = 5000;
 
 // Help Logic
 exports.getHelpPage = async function(req, res, next)
@@ -32,6 +36,10 @@ exports.getHelpPage = async function(req, res, next)
         const helpPageData = {
             isAwaitingLogin: !isUserLoggedIn
         };
+
+        // Set a cookie with a timestamp of when the help page was last loaded
+        pageLoadTimeStamp = Date.now();
+        cookie.setCookie(req, res, pageLoadKey, pageLoadTimeStamp); // Session cookie (no explicit expiration)
 
         // Render the help page that the user can interact with
         res.location("/help");
@@ -48,20 +56,26 @@ exports.sendContactEmail = async function(req, res)
 {
     try
     {
-        // Force sending emails in development environment (used only for testing)
-        const forceSendEmail = true;
+        // Determine if we should send a contact form email by validating the user is likely not a bot
+        // Page load time to form submit time should be over a reasonable amount (a few seconds) for a human
+        const pageLoadTimeStamp = await cookie.getCookie(req, pageLoadKey);
 
-        // Attempt to send an email from contact form to admin based on the user's inputs
-        const contactEmailConnection = await getContactEmailConnection();
-        const contactEmailMessage = await getContactEmailMessage(req);
-        await emailUtils.sendEmailMessage(contactEmailConnection, contactEmailMessage, forceSendEmail);
+        formSubmitTimeStamp = Date.now();
+        const sendEmail = formSubmitTimeStamp - pageLoadTimeStamp >= pageLoadToFormSubmitHumanLowerLimitInMsec;
+        if (sendEmail)
+        {
+            // Attempt to send an email from contact form to admin based on the user's inputs
+            const contactEmailConnection = await getContactEmailConnection();
+            const contactEmailMessage = await getContactEmailMessage(req);
+            await emailUtils.sendEmailMessage(contactEmailConnection, contactEmailMessage);
 
-        // Also, attempt to send confirmation email to the user
-        const confirmationEmailConnection = await getConfirmationEmailConnection();
-        const confirmationEmailMessage = await getConfirmationEmailMessage(req, contactEmailMessage);
-        await emailUtils.sendEmailMessage(confirmationEmailConnection, confirmationEmailMessage, forceSendEmail);
+            // Also, attempt to send confirmation email to the user
+            const confirmationEmailConnection = await getConfirmationEmailConnection();
+            const confirmationEmailMessage = await getConfirmationEmailMessage(req, contactEmailMessage);
+            await emailUtils.sendEmailMessage(confirmationEmailConnection, confirmationEmailMessage);
+        }
 
-        // Send a success status code back to the user if the emails were successful
+        // Send a success status code back to the user if the emails were successful (or if we suspect bot activity)
         res.sendStatus(successCode);
     }
     catch (error)

--- a/modules/utilityModules/authorize.js
+++ b/modules/utilityModules/authorize.js
@@ -257,7 +257,7 @@ exports.setAuthorizationCookies = function(req, res, auth)
             maxAge: auth.tokenExpirationInMsec
         };
         cookie.setCookie(req, res, accessKey, accessTypeAndToken, cookieSettings);
-        cookie.setCookie(req, res, refreshKey, auth.refreshToken); // Session cookie (no explicit expiration);
+        cookie.setCookie(req, res, refreshKey, auth.refreshToken); // Session cookie (no explicit expiration)
 
         // No return value, just indicate success
         return Promise.resolve();


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
Recently, many bots have uncovered the contact form on the help page that is public facing.  They have decided to spam it with frequent e-mails, so I am developing light measures to determine if the form was submitted by a human or a bot.

The check is a speed test.  If the time between page load and form submit is less than 5 seconds, chances are, it's a bot that is trying to send a contact me e-mail.

If it's over that, it's likely either a really _slow_ bot or a reasonable human.

I've opted to do something light-weight and rudimentary like this rather than implement something more complex and potentially not worth it (read: bloaty) like reCAPTCHA or other more powerful tooling.

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested locally to ensure that (with garbage inputs and under 5 seconds) a bot or bad actor spamming the form will simply see a silent success message without sending an e-mail out via the contact form.