### PR TITLE
Upgrade Node Version Used to v14

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,11 +37,11 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -52,7 +52,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -66,4 +66,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -30,39 +30,75 @@ jobs:
         USER: ${{ secrets.SYNC_USER }}
         KEY:  ${{ secrets.SYNC_SSH_PRIVATE_KEY }}
         TARGET: ${{ secrets.SYNC_TARGET_PATH }}
-        ARGS_MORE: '--exclude=/node_modules/ -vvv'
+        ARGS_MORE: '--exclude=/node_modules/'
         SSH_ARGS: '-p ${{ secrets.SYNC_PORT }} -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=quiet'
         MODE: push
         RUN_SCRIPT_ON: source
         VERBOSE: true
 
-    - name: Remote Package Install via SSH
+    - name: Verify Symbolic Links via SSH
       uses: appleboy/ssh-action@v0.1.4
       env:
-        NODE_MODULES_PATH: ${{ secrets.NODE_MODULES_TARGET_PATH }}
-        NPM_PATH: ${{ secrets.NPM_TARGET_PATH }}
+        NODE_VERSION: 14
+        HOME_DIRECTORY: ${{ secrets.HOME_DIRECTORY_PATH }}
+        CODE_PATH: ${{ secrets.SYNC_TARGET_PATH }}
       with:
         host: ${{ secrets.SYNC_SERVER }}
         port: ${{ secrets.SYNC_PORT }}
         username: ${{ secrets.SYNC_USER }}
         key: ${{ secrets.SYNC_SSH_PRIVATE_KEY }}
         script_stop: true
-        envs: NODE_MODULES_PATH, NPM_PATH
-        script: $NPM_PATH/npm install $NODE_MODULES_PATH
+        envs: NODE_VERSION, HOME_DIRECTORY, CODE_PATH
+        script: |
+          NODE_VENV_PATH=$HOME_DIRECTORY/nodevenv/node
+          NODE_MODULES_PATH=$NODE_VENV_PATH/$NODE_VERSION/lib
+          EXIT_CODE=0
+          if [ ! -L "$NODE_MODULES_PATH/package.json" ] || [ ! -e "$NODE_MODULES_PATH/package.json" ] || [ "$CODE_PATH/package.json" != "$(readlink $NODE_MODULES_PATH/package.json)" ]; then
+              echo "Expected symbolic link to file 'package.json', but the symbolic link file was not found, is broken, or is pointing to the incorrect path."
+              echo "Cannot execute remote install without reference to file: 'package.json'."
+              EXIT_CODE=1
+          fi
+          if [ ! -L "$NODE_MODULES_PATH/package-lock.json" ] || [ ! -e "$NODE_MODULES_PATH/package-lock.json" ] || [ "$CODE_PATH/package-lock.json" != "$(readlink $NODE_MODULES_PATH/package-lock.json)" ]; then
+              echo "Expected symbolic link to file 'package-lock.json', but the symbolic link file was not found, is broken, or is pointing to the incorrect path."
+              echo "Cannot execute remote install without reference to file: 'package-lock.json'."
+              EXIT_CODE=1
+          fi
+          exit $EXIT_CODE
+
+    - name: Remote Package Install via SSH
+      uses: appleboy/ssh-action@v0.1.4
+      env:
+        NODE_VERSION: 14
+        HOME_DIRECTORY: ${{ secrets.HOME_DIRECTORY_PATH }}
+      with:
+        host: ${{ secrets.SYNC_SERVER }}
+        port: ${{ secrets.SYNC_PORT }}
+        username: ${{ secrets.SYNC_USER }}
+        key: ${{ secrets.SYNC_SSH_PRIVATE_KEY }}
+        script_stop: true
+        envs: NODE_VERSION, HOME_DIRECTORY
+        script: |
+          NODE_VENV_PATH=$HOME_DIRECTORY/nodevenv/node
+          NODE_MODULES_PATH=$NODE_VENV_PATH/$NODE_VERSION/lib
+          NPM_PATH=$NODE_VENV_PATH/$NODE_VERSION/bin
+          $NPM_PATH/npm install $NODE_MODULES_PATH
 
     - name: Remote Server Restart via SSH
       uses: appleboy/ssh-action@v0.1.4
       env:
-        VENV_ACTIVATION_PATH: ${{ secrets.VENV_ACTIVATION_TARGET_PATH }}
+        NODE_VERSION: 14
+        HOME_DIRECTORY: ${{ secrets.HOME_DIRECTORY_PATH }}
         CODE_PATH: ${{ secrets.SYNC_TARGET_PATH }}
-        SELECTOR_PATH: ${{ secrets.SELECTOR_TARGET_PATH }}
       with:
         host: ${{ secrets.SYNC_SERVER }}
         port: ${{ secrets.SYNC_PORT }}
         username: ${{ secrets.SYNC_USER }}
         key: ${{ secrets.SYNC_SSH_PRIVATE_KEY }}
         script_stop: true
-        envs: VENV_ACTIVATION_PATH, CODE_PATH, SELECTOR_PATH
+        envs: NODE_VERSION, HOME_DIRECTORY, CODE_PATH
         script: |
+          NODE_VENV_PATH=$HOME_DIRECTORY/nodevenv/node
+          VENV_ACTIVATION_PATH=$NODE_VENV_PATH/$NODE_VERSION/bin
+          SELECTOR_PATH=/usr/sbin
           source $VENV_ACTIVATION_PATH/activate && cd $CODE_PATH
           $SELECTOR_PATH/cloudlinux-selector restart --json --interpreter nodejs --app-root $CODE_PATH

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: '14.x'
+        node-version: 14
 
     - name: Install Projects via NPM
       run: npm ci

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '14.x'
 
     - name: Install Projects via NPM
       run: npm ci

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '14.x'
 
     - name: Install Projects via NPM
       run: npm ci
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '14.x'
 
     - name: Install Projects via NPM
       run: npm ci
@@ -54,7 +54,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '14.x'
 
     - name: Install Projects via NPM
       run: npm ci

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  lint-js:
+  lint:
     runs-on: ubuntu-latest
     name: Lint JavaScript Files
     steps:
@@ -23,41 +23,5 @@ jobs:
     - name: Install Projects via NPM
       run: npm ci
 
-    - name: Lint JS
-      run: npm run lint:js
-
-  lint-html:
-    runs-on: ubuntu-latest
-    name: Lint HTML Files
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v2
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '14.x'
-
-    - name: Install Projects via NPM
-      run: npm ci
-
-    - name: Lint HTML
-      run: npm run lint:html
-
-  lint-vash:
-    runs-on: ubuntu-latest
-    name: Lint Vash Files
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v2
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '14.x'
-
-    - name: Install Projects via NPM
-      run: npm ci
-
-    - name: Lint Vash
-      run: npm run lint:vash
+    - name: Lint
+      run: npm run lint

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,12 +13,12 @@ jobs:
     name: Lint JavaScript Files
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: '14.x'
+        node-version: 14
 
     - name: Install Projects via NPM
       run: npm ci

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,7 +10,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    name: Lint JavaScript Files
+    name: Lint Repository Files
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "license": "MIT",
     "repository": "github:iansantagata/jamms",
     "engines": {
-        "node": "=12.22.9",
-        "npm": "=6.14.15"
+        "node": "=14.21.2",
+        "npm": "=6.14.17"
     },
     "scripts": {
         "lint": "npm run lint:js && npm run lint:html && npm run lint:vash",


### PR DESCRIPTION
### Overview
<!-- A brief overview of the problem or issue this change resolves and how it does so -->
Upgrades code and architecture to utilize Node v14 rather than Node v12.

There is also some clean-up of GitHub Actions code to make the actions and deploy process less opaque:

- Reduced duplication and complexity in GitHub Actions
- Consolidated related secrets, especially file path related ones
- Lint all files at once in a single job instead of splitting out linting
- Replace GitHub branch protection rules for each lint checks with single all-encompassing lint check

As part of this, the architecture will need to switch to using Node v14 as well (outside of this PR)

### Testing
<!-- Some examples of how this code was tested and with what data or in what contexts / cases. -->
<!-- Note - These details should be descriptive and specific enough so that if someone else pulled down the branch and read these testing details, they could realistically test the same way. -->
Tested utilizing a similar repository and deploying these changes in chunks.

#### Additional Notes
<!-- This section can optionally be included if there is anything else in particular to note about this PR, like surrounding context, the issues it uncovered or resolved, etc. -->
Addresses this issue: https://github.com/iansantagata/JAMMS/issues/124

